### PR TITLE
[Feat/#169] 회의 입장페이지에서 회의명 보여주기

### DIFF
--- a/src/pages/SteppingStone/SteppingLayout.tsx
+++ b/src/pages/SteppingStone/SteppingLayout.tsx
@@ -16,9 +16,13 @@ function SteppingLayout({ steppingType }: SteppingProps) {
   const navigate = useNavigate();
   const { meetingId } = useParams();
 
+  const [meetingTitle, setMeetingTitle] = useState('');
+
   const isConfirmedMeet = async () => {
+    // 회의명 붙이기
     const result = await client.get(`/meeting/${meetingId}`);
-    console.log(result);
+
+    setMeetingTitle(result.data.data.title);
     if (result.data.code === 409) {
       navigate(`/q-card/${meetingId}`);
     }
@@ -37,7 +41,7 @@ function SteppingLayout({ steppingType }: SteppingProps) {
     <>
       <SteppingWrapper>
         <Header position={'stepping'} />
-        <SteppingBody steppingType={steppingType} />
+        <SteppingBody steppingType={steppingType} meetingTitle={meetingTitle} />
         <SteppingBtnSection steppingType={steppingType} />
       </SteppingWrapper>
     </>

--- a/src/pages/SteppingStone/components/SteppingBody.tsx
+++ b/src/pages/SteppingStone/components/SteppingBody.tsx
@@ -37,7 +37,7 @@ const bodyType: BodyType = {
   },
   meetEntrance: {
     img: <img src={stepingPlus} alt="png" />,
-    main: '에이셉 전체회의', // 찬우오빠.. 내가 범인 찾았어 - 2023.09.11 은서가
+    main: '',
     sub: (
       <>
         <Text font={'title2'} color={`${theme.colors.grey4}`}>
@@ -67,16 +67,17 @@ const bodyType: BodyType = {
 
 interface SteppingProps {
   steppingType: string;
+  meetingTitle?: string;
 }
 
-function SteppingBody({ steppingType }: SteppingProps) {
+function SteppingBody({ steppingType, meetingTitle }: SteppingProps) {
   const stepInfo = bodyType[steppingType];
   return (
     <SteppingBodyWrapper>
       <ImageSection>{stepInfo.img}</ImageSection>
       <SteppingMentSection>
         <Text font={'head1'} color={`${theme.colors.white}`}>
-          {stepInfo.main}
+          {meetingTitle ? meetingTitle : stepInfo.main}
         </Text>
         <SubMentWrapper>{stepInfo.sub}</SubMentWrapper>
       </SteppingMentSection>


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label, Milestone 붙이기 --> 

### ✨ 해당 이슈 번호 ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
#129

### todo 
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->
- [x] 회의명 변경

## 📌 내가 알게 된 부분
<!-- 새롭게 알게 된 부분을 적기 (기록하면서 개발하기!) -->
- 

## 📌 공유하고 싶은 부분
<!-- 새롭게 알게 된 부분을 적기 (기록하면서 개발하기!) -->
- 기존에 회의 입장할 때 방장이 입력한 회의명이 아니라 '에이셉 전체회의' 라는 문구가 하드코딩 되어있던 것이 문제였는데요.
회의 입장페이지에서 해당 회의가 유효한 회의인지 (이미 확정된 회의인지) 확인하는 api를 쏘는데, 해당 요청에 대한 응답으로 회의명을 받아올 수 있도록 서버측에 요청해서 해결했습니다.

- 찬우오빠가 모든 퍼널의 공통적인 요소들을 SteppingStone이라는 공통컴포넌트로 구현했는데, 그래서 회의명에 해당하는 부분도 'SteppingBody'라는 공통 컴포넌트로 나타내고 있었습니다. 이 컴포넌트에 api 응답으로 받아온 회의명을 prop으로 넘겨주어야해서, SteppingBody 컴포넌트에 meetingTitle이라는 prop을 추가했고, 회의 입장 페이지 외에는 이 prop이 필요하지 않기 때문에 type은 undefined를 허용했습니다.

- 워낙 공통컴포넌트가 깔쌈하게 되어있었어서 이 한 페이지를 위해 prop을 추가한게 썩 만족스럽지는 않은데... 전역상태관리로 해결했어야하나 싶기도 하구요...

## 📌 질문할 부분 
<!-- 작은 거라도 좋아요! (같이 성장하기)  -->
-

## 📌스크린샷
https://github.com/ASAP-as-soon-as-possible/ASAP_Client/assets/55528304/96dcada8-352d-4032-b006-df294e2f91d6

입장페이지 새로고침하는 영상인데, 보다시피 api 응답 받아오는데 시간이 걸려서 잠깐동안 빈 글자로 나옵니다 ㅠㅠ
흠 이걸 어떻게 해결하면 좋을지....