### PR TITLE
[ Fix / toastCreate / #178 ] toast 무한 생성 버그 수정

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
   <meta property="og:title" content="모든 회의의 시작, ASAP" />
   <meta property="og:description" content="ASAP 최적의 회의시간을 도출하세요" />
   <meta property="og:image" content="https://github.com/ASAP-as-soon-as-possible/ASAP_Client/assets/91375979/8a4ec3f0-ce85-4a3e-844a-d21391c4c6ec">
+  <meta name="naver-site-verification" content="6b03e31b9187ec727bf2fe5c82eb98eaa6a05ce5" />
   <title>ASAP, 최적의 회의시간 도출서비스</title>
 </head>
 

--- a/index.html
+++ b/index.html
@@ -12,7 +12,8 @@
   <meta property="og:description" content="ASAP 최적의 회의시간을 도출하세요" />
   <meta property="og:image" content="https://github.com/ASAP-as-soon-as-possible/ASAP_Client/assets/91375979/8a4ec3f0-ce85-4a3e-844a-d21391c4c6ec">
   <meta name="naver-site-verification" content="6b03e31b9187ec727bf2fe5c82eb98eaa6a05ce5" />
-  <title>ASAP, 최적의 회의시간 도출서비스</title>
+  <title>ASAP</title>
+  <meta name="description" content="최적의 회의시간을 도출하세요.">
 </head>
 
 <body>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow: /

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset
+      xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
+            http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
+<!-- created with Free Online Sitemap Generator www.xml-sitemaps.com -->
+
+
+<url>
+  <loc>https://www.beginwithasap.com/</loc>
+  <lastmod>2023-07-27T14:09:18+00:00</lastmod>
+</url>
+
+
+</urlset>

--- a/src/pages/SteppingStone/SteppingLayout.tsx
+++ b/src/pages/SteppingStone/SteppingLayout.tsx
@@ -1,12 +1,11 @@
+import { authClient, client } from 'utils/apis/axios';
 import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
 
 import Header from 'components/moleculesComponents/Header';
-import { useNavigate, useParams } from 'react-router-dom';
-import styled from 'styled-components/macro';
-import { authClient, client } from 'utils/apis/axios';
-
 import SteppingBody from './components/SteppingBody';
 import SteppingBtnSection from './components/SteppingBtnSection';
+import styled from 'styled-components/macro';
 
 interface SteppingProps {
   steppingType: string;
@@ -28,6 +27,7 @@ function SteppingLayout({ steppingType }: SteppingProps) {
     }
   };
 
+  //git test
   useEffect(
     () => {
       if (steppingType === 'meetEntrance') {

--- a/src/utils/toast/ToastContainer.tsx
+++ b/src/utils/toast/ToastContainer.tsx
@@ -10,10 +10,11 @@ function ToastContainerBox() {
       newestOnTop={false}
       closeOnClick
       rtl={false}
-      pauseOnFocusLoss
+      pauseOnFocusLoss={true}
       draggable
       pauseOnHover
       theme="dark"
+      limit={1}
     />
   );
 }

--- a/src/utils/toast/copyLink.ts
+++ b/src/utils/toast/copyLink.ts
@@ -1,5 +1,7 @@
 import { toast } from 'react-toastify';
 
-export const notify = () => toast('링크 복사가 완료되었습니다');
+export const notify = () => toast('링크 복사가 완료되었습니다', {toastId: "1"});
 
 export const downLoadNotify = () => toast('이미지 다운로드를 시작합니다');
+
+export const dismissTostify=()=>toast.dismiss();

--- a/src/utils/toast/copyLink.ts
+++ b/src/utils/toast/copyLink.ts
@@ -3,3 +3,4 @@ import { toast } from 'react-toastify';
 export const notify = () => toast('링크 복사가 완료되었습니다', {toastId: "link"});
 
 export const downLoadNotify = () => toast('이미지 다운로드를 시작합니다');
+//test

--- a/src/utils/toast/copyLink.ts
+++ b/src/utils/toast/copyLink.ts
@@ -1,7 +1,5 @@
 import { toast } from 'react-toastify';
 
-export const notify = () => toast('링크 복사가 완료되었습니다', {toastId: "1"});
+export const notify = () => toast('링크 복사가 완료되었습니다', {toastId: "link"});
 
 export const downLoadNotify = () => toast('이미지 다운로드를 시작합니다');
-
-export const dismissTostify=()=>toast.dismiss();


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label, Milestone 붙이기 --> 

### ✨ 해당 이슈 번호 ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
#178 

### todo 
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->
- [x] 토스트 창 하나만 띄어지게 하기
- [x] 토스트 창이 다음 페이지 넘어가는 것을 막기

## 📌 내가 알게 된 부분
<!-- 새롭게 알게 된 부분을 적기 (기록하면서 개발하기!) -->
- toast 를 생성할 땐 id값을 넣어줘야 예상 가능하게 작동한다 (광클해도 한 번만 뜹니다. dismiss같은 속성도 이용가능하구요)

## 📌 공유하고 싶은 부분
<!-- 새롭게 알게 된 부분을 적기 (기록하면서 개발하기!) -->
- toastContainer는 app (route)에 넣는 것이 권장됩니다.
- toast는 id를 사용하면 연속적으로 마구잡이로 생성되지 않습니다.
- limit속성은 최대 몇개 띄울 것이냐 인데 id가 없어도 동작은하지만 한개를 계~~속 띄우게되니 id를 사용해야합나다.

## 📌 질문할 부분 
<!-- 작은 거라도 좋아요! (같이 성장하기)  -->
-없음!

## 📌스크린샷
https://github.com/ASAP-as-soon-as-possible/ASAP_Client/assets/81609304/71eea8f9-8380-43ec-999c-a9397806b1f7



