### PR TITLE
[Feat/#184] MacOS 사파리 명조체

### DIFF
--- a/src/components/atomComponents/Text.tsx
+++ b/src/components/atomComponents/Text.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components/macro';
 
 interface ValueProps {
-  children: string | string[];
+  children: string | string[] | number;
   font: string;
   color?: string;
 }

--- a/src/pages/BestMeetTime/components/bestMeetTime/BestMeetTime.tsx
+++ b/src/pages/BestMeetTime/components/bestMeetTime/BestMeetTime.tsx
@@ -35,9 +35,22 @@ function BestMeetTime() {
           <TitleSection>
             <HeaderContainer>
               <HeaderTitle>
-                현재까지 모인 <MemberCount>{bestTimeData.data.memberCount}</MemberCount>명을 위한
+                <Text font={`head2`} color={`${theme.colors.white}`}>
+                  현재까지 모인&nbsp;
+                </Text>
+                <Text font={`head2`} color={`${theme.colors.sub1}`}>
+                  {bestTimeData.data.memberCount}
+                </Text>
+                <Text font={`head2`} color={`${theme.colors.sub1}`}>
+                  명
+                </Text>
+                <Text font={`head2`} color={`${theme.colors.white}`}>
+                  을 위한
+                </Text>
               </HeaderTitle>
-              <HeaderTitle>최적의 회의시간이에요</HeaderTitle>
+              <Text font={`head2`} color={`${theme.colors.white}`}>
+                최적의 회의시간이에요
+              </Text>
             </HeaderContainer>
             <Text font={'body3'} color={`${theme.colors.grey4}`}>
               박스를 클릭하여 회의시간을 확정해주세요
@@ -129,14 +142,7 @@ const HeaderContainer = styled.div`
 `;
 
 const HeaderTitle = styled.div`
-  line-height: 3rem;
-  color: ${({ theme }) => theme.colors.white};
-  font-size: 2.2rem;
-  font-weight: 700;
-`;
-
-const MemberCount = styled.span`
-  color: ${({ theme }) => theme.colors.sub1};
+  display: flex;
 `;
 
 const AnotherTimeBtnSection = styled.div`


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label, Milestone 붙이기 --> 

### ✨ #184  ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->

### todo 
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->
- [x] 사파리에서 방장페이지 일부가 명조체로 보이는 문제 해결

## 📌 내가 알게 된 부분
<!-- 새롭게 알게 된 부분을 적기 (기록하면서 개발하기!) -->
- '사파리 명조체 이슈' 라고 하기는 했는데, 오로지 방장페이지의 제목 부분만 명조체가 나오는 걸 보아 브라우저별 폰트 호환성 문제가 아니라 다른 방향으로 접근해야겠다는 생각이 들었습니다.
- 명조체로 나오는 부분을 개발자도구에서 찍어보니 역시 font-family 속성 자체가 없드라구요... 해당 요소에 폰트가 적용이 안된 것이었습니다.
- 그래서 사파리 외에 다른 브라우저에서도 사실 해당 부분에 폰트가 적용이 안되어있습니다. 단지 애플 기본 폰트와 Pretendard가 크게 다르게 생기지 않아서 티가 안나는 것이었습니다.
- 역시 문제의 원인을 파악하는 것은 중요합니다.
- 해당 부분이 '현재까지 모인' + '1(변동되는 부분)' + '명을 위한 최적의 회의시간이에요' 이렇게 텍스트가 구성되어야 하는데, Text 공통 컴포넌트의 children으로 이렇게 혼합된 요소를 넣을 수가 없어서, 찬우오빠가 일단 빠른 구현을 위해 Text 컴포넌트가 아닌 div를 사용하다가 폰트 적용하는걸 깜빡한 것 같습니다. 
<img width="245" alt="image" src="https://github.com/ASAP-as-soon-as-possible/ASAP_Client/assets/55528304/b62bdca9-e508-403a-9cbb-f746d61cfd44">
<img width="245" alt="image" src="https://github.com/ASAP-as-soon-as-possible/ASAP_Client/assets/55528304/7b1b4cf7-b680-46e2-a354-13e19a7960ca">
<br/>
전자는 Pretendard, 후자는 Apple Gothic인데 특히 ㅎ의 모양이 다른 걸 보실 수 있습니다. 그치만 자세히보지 않으면 티가 안남<br/>
더불어서 원래 '명'이라는 글자또한 초록색이어야 하는데 현재 배포본에는 '명'도 흰색인걸 보실 수 있습니다

- 그래서 Text 컴포넌트의 맹점에 대해서 생각하게 되네요... 복잡한 chlidren을 넣기가 너무 까다로워집니다. 변동되는 인원수(number)를 Text컴포넌트의 자식으로 넣기 위해서 Text 컴포넌트의 자식 type에 number를 추가했습니다.
- 또한, 이런식으로 구현하면 문장의 첫번째줄과 두번째 줄을 각각의 Text컴포넌트로 구현해야 하는데, 그러면 줄간격이 디자이너가 의도한 것과 달라질 수 있다는 문제점도 있습니다.


## 📌스크린샷
### 변경 전(사파리)
<img width="378" alt="image" src="https://github.com/ASAP-as-soon-as-possible/ASAP_Client/assets/55528304/56caed4a-0f3c-436d-9b2d-04bc1dd8781e">
<br/>

### 변경 후(사파리)
<img width="378" alt="image" src="https://github.com/ASAP-as-soon-as-possible/ASAP_Client/assets/55528304/5c408d95-e408-4d89-bf24-2f5c1720ff3d">
