### PR TITLE
[Feat/#188] 확정된 회의 링크 입장시 리다이렉션

### DIFF
--- a/src/pages/SteppingStone/SteppingLayout.tsx
+++ b/src/pages/SteppingStone/SteppingLayout.tsx
@@ -1,11 +1,12 @@
-import { authClient, client } from 'utils/apis/axios';
 import { useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
 
 import Header from 'components/moleculesComponents/Header';
+import { useNavigate, useParams } from 'react-router-dom';
+import styled from 'styled-components/macro';
+import { authClient, client } from 'utils/apis/axios';
+
 import SteppingBody from './components/SteppingBody';
 import SteppingBtnSection from './components/SteppingBtnSection';
-import styled from 'styled-components/macro';
 
 interface SteppingProps {
   steppingType: string;
@@ -20,10 +21,10 @@ function SteppingLayout({ steppingType }: SteppingProps) {
   const isConfirmedMeet = async () => {
     // 회의명 붙이기
     const result = await client.get(`/meeting/${meetingId}`);
-
-    setMeetingTitle(result.data.data.title);
     if (result.data.code === 409) {
       navigate(`/q-card/${meetingId}`);
+    } else {
+      setMeetingTitle(result.data.data.title);
     }
   };
 


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label, Milestone 붙이기 --> 

### ✨ #188 ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->

### todo 
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->
- [x] 확정된 회의 링크 입장시 리다이렉션

## 📌 내가 알게 된 부분
<!-- 새롭게 알게 된 부분을 적기 (기록하면서 개발하기!) -->
- state 변경 시기를 항상 주의할 것

## 📌 공유하고 싶은 부분
<!-- 새롭게 알게 된 부분을 적기 (기록하면서 개발하기!) -->
- 회의명 보여주는 부분을 처리하면서 원래 없던 setState를 추가했는데, 현재 이 방이 확정된 회의인지 아닌지를 판단하기 전에 setState를 실행하여 오류가 나게되는 간단한 상황이었습니다. 순서를 조정하여 해결하였습니다.

## 📌스크린샷

https://github.com/ASAP-as-soon-as-possible/ASAP_Client/assets/55528304/54d246d6-7beb-4c8a-b0e3-6d1a40365eee


확정된 회의이므로 바로 리다이렉트되는 모습
