### PR TITLE
[Fix/#195] 삼성인터넷/크롬 선택지 없이 바로 삼성인터넷으로 우회

### DIFF
--- a/src/utils/changeBrowser.ts
+++ b/src/utils/changeBrowser.ts
@@ -10,18 +10,12 @@ inappdeny_exec_vanillajs(() => {
   /* Do things after DOM has fully loaded */
 
   function copytoclipboard(val: string) {
-    const t = document.createElement("textarea");
+    const t = document.createElement('textarea');
     document.body.appendChild(t);
     t.value = val;
     t.select();
     document.execCommand('copy');
     document.body.removeChild(t);
-  }
-
-  function inappbrowserout() {
-    copytoclipboard(window.location.href);
-    alert('URL주소가 복사되었습니다.\n\nSafari가 열리면 주소창을 길게 터치한 뒤, "붙여놓기 및 이동"을 누르면 정상적으로 이용하실 수 있습니다.');
-    location.href = 'x-web-search://?';
   }
 
   const useragt = navigator.userAgent.toLowerCase();
@@ -37,23 +31,33 @@ inappdeny_exec_vanillajs(() => {
     } else {
       location.href = target_url + '?openExternalBrowser=1';
     }
-  } else if (useragt.match(/inapp|naver|snapchat|wirtschaftswoche|thunderbird|instagram|everytimeapp|whatsApp|electron|wadiz|aliapp|zumapp|iphone(.*)whale|android(.*)whale|kakaostory|band|twitter|DaumApps|DaumDevice\/mobile|FB_IAB|FB4A|FBAN|FBIOS|FBSS|SamsungBrowser\/[^1]/i)) {
+  } else if (
+    useragt.match(
+      /inapp|naver|snapchat|wirtschaftswoche|thunderbird|instagram|everytimeapp|whatsApp|electron|wadiz|aliapp|zumapp|iphone(.*)whale|android(.*)whale|kakaostory|band|twitter|DaumApps|DaumDevice\/mobile|FB_IAB|FB4A|FBAN|FBIOS|FBSS|SamsungBrowser\/[^1]/i,
+    )
+  ) {
     // 그 외 다른 인앱들
     if (useragt.match(/iphone|ipad|ipod/i)) {
       // 아이폰은 강제로 사파리를 실행할 수 없다 ㅠㅠ
       // 모바일 대응 뷰포트 강제 설정
       const mobile = document.createElement('meta');
       mobile.name = 'viewport';
-      mobile.content = "width=device-width, initial-scale=1, shrink-to-fit=no, user-scalable=no, minimal-ui";
+      mobile.content =
+        'width=device-width, initial-scale=1, shrink-to-fit=no, user-scalable=no, minimal-ui';
       document.getElementsByTagName('head')[0].appendChild(mobile);
       // 노토산스 폰트 강제 설정
       const fonts = document.createElement('link');
-      fonts.href = 'https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@100;300;400;500;700;900&display=swap';
+      fonts.href =
+        'https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@100;300;400;500;700;900&display=swap';
       document.getElementsByTagName('head')[0].appendChild(fonts);
-      document.body.innerHTML = "<style>body{margin:0;padding:0;font-family: 'Noto Sans KR', sans-serif;overflow: hidden;height: 100%;}</style><h2 style='padding-top:50px; text-align:center;font-family: 'Noto Sans KR', sans-serif;'>인앱브라우저 호환문제로 인해<br />Safari로 접속해야합니다.</h2><article style='text-align:center; font-size:17px; word-break:keep-all;color:#999;'>아래 버튼을 눌러 Safari를 실행해주세요<br />Safari가 열리면, 주소창을 길게 터치한 뒤,<br />'붙여놓기 및 이동'을 누르면<br />정상적으로 이용할 수 있습니다.<br /><br /><button onclick='inappbrowserout();' style='min-width:180px;margin-top:10px;height:54px;font-weight: 700;background-color:#31408E;color:#fff;border-radius: 4px;font-size:17px;border:0;'>Safari로 열기</button></article><img style='width:70%;margin:50px 15% 0 15%' src='https://tistory3.daumcdn.net/tistory/1893869/skin/images/inappbrowserout.jpeg' />";
-    } else {
+      document.body.innerHTML =
+        "<style>body{margin:0;padding:0;font-family: 'Noto Sans KR', sans-serif;overflow: hidden;height: 100%;}</style><h2 style='padding-top:50px; text-align:center;font-family: 'Noto Sans KR', sans-serif;'>인앱브라우저 호환문제로 인해<br />Safari로 접속해야합니다.</h2><article style='text-align:center; font-size:17px; word-break:keep-all;color:#999;'>아래 버튼을 눌러 Safari를 실행해주세요<br />Safari가 열리면, 주소창을 길게 터치한 뒤,<br />'붙여놓기 및 이동'을 누르면<br />정상적으로 이용할 수 있습니다.<br /><br /><button onclick='inappbrowserout();' style='min-width:180px;margin-top:10px;height:54px;font-weight: 700;background-color:#31408E;color:#fff;border-radius: 4px;font-size:17px;border:0;'>Safari로 열기</button></article><img style='width:70%;margin:50px 15% 0 15%' src='https://tistory3.daumcdn.net/tistory/1893869/skin/images/inappbrowserout.jpeg' />";
+    } /* else if (useragt.match(/samsungbrowser/)) {
       // 안드로이드는 Chrome이 설치되어 있음으로 강제로 스킴 실행
-      location.href = 'intent://' + target_url.replace(/https?:\/\//i, '') + '#Intent;scheme=http;package=com.android.chrome;end';
-    }
+      location.href =
+        'intent://' +
+        target_url.replace(/https?:\/\//i, '') +
+        '#Intent;scheme=http;package=com.android.chrome;end';
+    } */
   }
 });


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label, Milestone 붙이기 --> 

### ✨ #195 ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->

### todo 
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->
- [x] 삼성인터넷/크롬 선택지 없이 바로 삼성인터넷으로 열리도록 한다.

## 📌 내가 알게 된 부분
<!-- 새롭게 알게 된 부분을 적기 (기록하면서 개발하기!) -->
- 스킴이라는거... 생소하네요 자료 찾기가 어려운 것 같아요 특히 삼성인터넷이다보니...

## 📌 공유하고 싶은 부분
<!-- 새롭게 알게 된 부분을 적기 (기록하면서 개발하기!) -->
- 카톡 인앱브라우저를 피하는 기능을 담당하는 changeBrowser.ts라는 파일의 `inappbrowserout`이라는 function에서 `navigator.userAgent`라는 값으로 현재 어떤 인앱으로 들어왔는지를 확인합니다. kakaotalk이라면 외부 브라우저를 호출하고, 이후 안드로이드라면 `location.href =
        'intent://' +
        target_url.replace(/https?:\/\//i, '') +
        '#Intent;scheme=http;package=com.android.chrome;end';`라는 코드를 통해 크롬을 띄우는 것이 원래 코드였습니다. 그런데 의도와는 다르게 크롬이 아니라 크롬/삼성인터넷 중 선택하는 모달창이 나왔었죠. 그 모달창에서 삼성인터넷을 선택하면 다시 같은 분기가 실행되어 같은 모달창이 뜨는 것이었습니다. 그 모달을 띄울지 말지를 조정하는 방법을 찾지 못했고 (스킴을 바꿔야하는걸까요.. 바꾼다면 어떻게...) 차선책으로 아예 안드로이드일 경우에- 라는 if분기를 삭제하니 모달이 뜨지 않고 바로 삼성인터넷으로 연결이 되었습니다.
- 혹시모르니 여러 브라우저에서 qa가 필요할 것 같습니다.
