### PR TITLE
[Fix/#194] 선호시간 선택 후 POST시 response 값에 따라 처리 수정

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -34,6 +34,7 @@ const Router = () => {
         <Route path="/q-card/:meetingId" element={<CueCard />} />
         <Route path="/loadingpage" element={<LoadingPage />} />
         <Route path="*" element={<ErrorPage404 />} />
+        <Route path="/error" element={<ErrorPage404 />} />
         <Route path="/select" element={<SelectPage />} />
       </Routes>
     </BrowserRouter>

--- a/src/pages/selectSchedule/SelectModal.tsx
+++ b/src/pages/selectSchedule/SelectModal.tsx
@@ -36,8 +36,6 @@ function SelectModal({ setShowModal }: ModalProps) {
         if (data.code === 201) {
           setShowModal(false);
           navigate(`/${auth}/schedule-complete/${meetingId}`);
-        } else if (data.code === 400) {
-          alert(`${data.message}`);
         } else {
           navigate('/error');
         }
@@ -63,8 +61,6 @@ function SelectModal({ setShowModal }: ModalProps) {
         if (data.code === 201) {
           setShowModal(false);
           navigate(`/${auth}/schedule-complete/${meetingId}`);
-        } else if (data.code === 400) {
-          alert(`${data.message}`);
         } else {
           navigate('/error');
         }
@@ -72,6 +68,7 @@ function SelectModal({ setShowModal }: ModalProps) {
       }
     } catch (e) {
       if (isAxiosError(e) && e.response) {
+        console.log(e.response.data);
         if (e.response.status === 400) {
           alert(`${e.response.data.message}`);
         } else {

--- a/src/pages/selectSchedule/SelectModal.tsx
+++ b/src/pages/selectSchedule/SelectModal.tsx
@@ -1,6 +1,7 @@
 import React, { Dispatch, useEffect, SetStateAction } from 'react';
 
 import { scheduleAtom, userNameAtom } from 'atoms/atom';
+import { isAxiosError } from 'axios';
 import Text from 'components/atomComponents/Text';
 import { ExitIc } from 'components/Icon/icon';
 import { useNavigate, useParams } from 'react-router';
@@ -35,14 +36,22 @@ function SelectModal({ setShowModal }: ModalProps) {
         if (data.code === 201) {
           setShowModal(false);
           navigate(`/${auth}/schedule-complete/${meetingId}`);
+        } else if (data.code === 400) {
+          alert(`${data.message}`);
         } else {
           navigate('/error');
         }
         return data.code;
       }
     } catch (e) {
-      console.error(e);
-      navigate(`/error`);
+      if (isAxiosError(e) && e.response) {
+        if (e.response.status === 400) {
+          alert(`${e.response.data.message}`);
+        } else {
+          console.error(e);
+          navigate(`/error`);
+        }
+      }
     }
   };
 
@@ -54,14 +63,22 @@ function SelectModal({ setShowModal }: ModalProps) {
         if (data.code === 201) {
           setShowModal(false);
           navigate(`/${auth}/schedule-complete/${meetingId}`);
+        } else if (data.code === 400) {
+          alert(`${data.message}`);
         } else {
           navigate('/error');
         }
         return data;
       }
     } catch (e) {
-      console.error(e);
-      navigate(`/error`);
+      if (isAxiosError(e) && e.response) {
+        if (e.response.status === 400) {
+          alert(`${e.response.data.message}`);
+        } else {
+          console.error(e);
+          navigate(`/error`);
+        }
+      }
     }
   };
 

--- a/src/pages/selectSchedule/SelectModal.tsx
+++ b/src/pages/selectSchedule/SelectModal.tsx
@@ -30,22 +30,38 @@ function SelectModal({ setShowModal }: ModalProps) {
   const postHostAvailableApi = async () => {
     try {
       if (meetingId && updateScheduleType) {
-        const data = await hostAvailableApi(meetingId, updateScheduleType);
-        return data;
+        const { data } = await hostAvailableApi(meetingId, updateScheduleType);
+        console.log(data);
+        if (data.code === 201) {
+          setShowModal(false);
+          navigate(`/${auth}/schedule-complete/${meetingId}`);
+        } else {
+          navigate('/error');
+        }
+        return data.code;
       }
     } catch (e) {
       console.error(e);
+      navigate(`/error`);
     }
   };
 
   const postMemberAvailableApi = async () => {
     try {
       if (meetingId && updateMemberScheduleType) {
-        const data = await userAvailableApi(meetingId, updateMemberScheduleType);
+        const { data } = await userAvailableApi(meetingId, updateMemberScheduleType);
+        console.log(data);
+        if (data.code === 201) {
+          setShowModal(false);
+          navigate(`/${auth}/schedule-complete/${meetingId}`);
+        } else {
+          navigate('/error');
+        }
         return data;
       }
     } catch (e) {
       console.error(e);
+      navigate(`/error`);
     }
   };
 
@@ -66,8 +82,8 @@ function SelectModal({ setShowModal }: ModalProps) {
       postMemberAvailableApi();
     }
 
-    setShowModal(false);
-    navigate(`/${auth}/schedule-complete/${meetingId}`);
+    // setShowModal(false);
+    // navigate(`/${auth}/schedule-complete/${meetingId}`);
   };
   return (
     <ReturnModalWrpper>

--- a/src/types/createAvailableSchduleType.ts
+++ b/src/types/createAvailableSchduleType.ts
@@ -9,6 +9,8 @@ export interface HostAvailableSchduleRequestType {
 }
 
 export interface HostAvailableScheduleResponseType {
+  code: number;
+  message: string;
   data: {
     url: string;
     accessToken: string;
@@ -32,6 +34,8 @@ export interface UserAvailableScheduleRequestTypeNull {
 }
 
 export interface UserAvailableScheduleResponseType {
+  code: number;
+  message: string;
   data: {
     role: string;
   };

--- a/src/utils/apis/createHostAvailableSchedule.ts
+++ b/src/utils/apis/createHostAvailableSchedule.ts
@@ -12,15 +12,12 @@ export const hostAvailableApi = (
   meetingId: string,
   reqBody: (HostAvailableSchduleRequestType | null)[],
 ) => {
-  return authClient.post<AxiosResponse<HostAvailableScheduleResponseType>>(
+  return authClient.post<HostAvailableScheduleResponseType>(
     `/user/host/${meetingId}/time`,
     reqBody,
   );
 };
 
 export const userAvailableApi = (meetingId: string, reqBody: UserAvailableScheduleRequestType) => {
-  return client.post<AxiosResponse<UserAvailableScheduleResponseType>>(
-    `/user/${meetingId}/time`,
-    reqBody,
-  );
+  return client.post<UserAvailableScheduleResponseType>(`/user/${meetingId}/time`, reqBody);
 };


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label, Milestone 붙이기 --> 

### ✨ 해당 이슈 번호 ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
#194 

### todo 
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->
- [x] 가능시간 post시 response로 201코드가 돌아온 경우에만 다음 페이지로 라우팅 처리
- [x] 그외에 400번대 오류 돌아오면 싹다 에러페이지로 라우팅
- [x] 에러코드 400인 경우에만 에러메세지 alert주고 해당 페이지 머무르기

## 📌 내가 알게 된 부분
<!-- 새롭게 알게 된 부분을 적기 (기록하면서 개발하기!) -->
- 서버에서 보내주기에 따라, 400코드 에러가 try에서 잡힐 수도, catch에서 잡힐 수도 있다! 서버와 협의 필요.
- 서버에서 리스폰스로 온 값의 에러처리를 할때, 타입스크립트 에서는 isAxiosError와 .response를 이용하여 타입스크립트의 안정성을 지킨다...!
- AxiosResponse -> 요놈 좀 문제가 있는 개념이다. 응답 시 응답 데이터 외의 header나 그외의 것들을 사용해야 하는것 아니라면, 이걸 쓸 필요 없이 그냥 응답 데이터에만 타입 지정해주고 쓰는게 낫다고 GPT가 그랬다. 응답 데이터를 이용하다가 발생한 타입에러에 관한 트러블 슈팅을 하다가 발견했다.

## 📌 공유하고 싶은 부분
<!-- 새롭게 알게 된 부분을 적기 (기록하면서 개발하기!) -->
- 400에러 시에만 alert로 전달받은 메세지를 띄우게 함
- 그 외에 catch로 간 에러는 전부 에러페이지로
- try에서도 201코드만 다음페이지 넘어가고 혹시 몰라서 다른건 전부 에러페이지로 가게 뒀다.

## 📌 질문할 부분 
<!-- 작은 거라도 좋아요! (같이 성장하기)  -->
<img width="701" alt="스크린샷 2023-10-12 오전 10 59 20" src="https://github.com/ASAP-as-soon-as-possible/ASAP_Client/assets/98143826/fa803b1f-88d1-420b-87a8-7ace37d76b4d">

- 타입 에러를 수정하려고 GPT에 물어봤더니 AxiosReponse를 지우래서 지웠더니 해결됐음.
<img width="805" alt="스크린샷 2023-10-12 오전 11 00 44" src="https://github.com/ASAP-as-soon-as-possible/ASAP_Client/assets/98143826/8f7d813a-fe6d-4814-9f53-488212e89cf6">

- 그래서 아래에 같은 코드를 위처럼 바꿈. 나중에 아래도 axiosresponse 지움. 근데 이거 재훈이형이 썼던데 axiosresponse를 쓴 이유가 따로 있나?

## 📌스크린샷
<img width="489" alt="스크린샷 2023-10-12 오전 11 13 48" src="https://github.com/ASAP-as-soon-as-possible/ASAP_Client/assets/98143826/15817365-1b23-456b-b7d4-e526fb07fc9f">

