### PR TITLE
[Fix/#202] 로그인시 숫자 키패드 뜨게하기

### DIFF
--- a/src/components/atomComponents/PasswordInput.tsx
+++ b/src/components/atomComponents/PasswordInput.tsx
@@ -26,7 +26,7 @@ function PasswordInput({ value, placeholder, passWordOnChange, page }: ValueProp
           value={value}
           onChange={passWordOnChange}
           $iserror={value.length < 4}
-          type={inputType ? `password` : undefined}
+          type={inputType ? `number` : undefined}
         />
         <IconContainer onClick={changePasswordType}>
           {inputType ? <PasswordOpenEyeIc /> : <PasswordEyeIc />}
@@ -61,16 +61,16 @@ const InputSection = styled.div`
   input:focus + div {
     display: flex;
     svg {
-      cursor: pointer;
       width: fit-content;
       height: fit-content;
+      cursor: pointer;
     }
   }
 `;
 
 const StyledPasswordInput = styled.input<{ $iserror: boolean }>`
   position: relative;
-  border:none;
+  border: none;
 
   border-radius: 0.8rem;
   box-shadow: 0 0.4rem 0.4rem 0 rgba(0, 0, 0, 0.25);

--- a/src/components/atomComponents/PasswordInput.tsx
+++ b/src/components/atomComponents/PasswordInput.tsx
@@ -27,6 +27,7 @@ function PasswordInput({ value, placeholder, passWordOnChange, page }: ValueProp
           onChange={passWordOnChange}
           $iserror={value.length < 4}
           type={inputType ? `number` : undefined}
+          inputmode="numeric"
         />
         <IconContainer onClick={changePasswordType}>
           {inputType ? <PasswordOpenEyeIc /> : <PasswordEyeIc />}

--- a/src/components/atomComponents/PasswordInput.tsx
+++ b/src/components/atomComponents/PasswordInput.tsx
@@ -27,7 +27,7 @@ function PasswordInput({ value, placeholder, passWordOnChange, page }: ValueProp
           onChange={passWordOnChange}
           $iserror={value.length < 4}
           type={inputType ? `number` : undefined}
-          inputmode="numeric"
+          inputMode="numeric"
         />
         <IconContainer onClick={changePasswordType}>
           {inputType ? <PasswordOpenEyeIc /> : <PasswordEyeIc />}

--- a/src/pages/createMeeting/components/useFunnel/SetHostInfo.tsx
+++ b/src/pages/createMeeting/components/useFunnel/SetHostInfo.tsx
@@ -25,8 +25,8 @@ function SetHostInfo({ meetingInfo, setMeetingInfo, setStep }: FunnelProps) {
       if (e.target.value.length < 9) {
         return { ...prev, password: e.target.value };
       }
-      alert("비밀번호는 8자리 이하로 말해주세요")
-      return { ...prev};
+      alert('비밀번호는 8자리 이하로 말해주세요');
+      return { ...prev };
     });
   };
 
@@ -64,7 +64,7 @@ function SetHostInfo({ meetingInfo, setMeetingInfo, setStep }: FunnelProps) {
           </Text>
           <PasswordInput
             value={meetingInfo.password}
-            placeholder={`방 비밀번호`}
+            placeholder={`숫자 4자리 이상`}
             passWordOnChange={passWordOnChange}
             page={'createMeeting'}
           />


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label, Milestone 붙이기 --> 

### ✨ 해당 이슈 번호 ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->

### todo 
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->
- [x] 비밀번호 입력 placeholder 수정
- [x] 비밀번호 입력시 일반 자판이 아닌 숫자 키패드 뜨게하기.

## 📌 내가 알게 된 부분
<!-- 새롭게 알게 된 부분을 적기 (기록하면서 개발하기!) -->
- type = number를 input에 속성으로 추가하면 안드는 숫자 키패드가 뜬다.
- ios는 이때 뜨긴 하지만, 아예 숫자 키패드가 아니라, 쿼티 자판의 숫자 입력 상태가 뜨는식. 
- 그래서 inputMode = numeric을 추가로 넣어주면 완전 키패드가 뜬다.

## 📌 공유하고 싶은 부분
<!-- 새롭게 알게 된 부분을 적기 (기록하면서 개발하기!) -->
- x

## 📌 질문할 부분 
<!-- 작은 거라도 좋아요! (같이 성장하기)  -->
- x

## 📌스크린샷
![IMG_6055](https://github.com/ASAP-as-soon-as-possible/ASAP_Client/assets/98143826/f42df68b-db50-4e47-9e25-fa5d2d87fd53)

