### PR TITLE
[Feat/#219] 회의 생성 후 바텀 시트 모달

### DIFF
--- a/src/components/atomComponents/Button.tsx
+++ b/src/components/atomComponents/Button.tsx
@@ -99,6 +99,11 @@ const buttonCSS = {
     background-color: transparent;
     color: ${({ theme }) => theme.colors.grey6};
   `,
+  quaternaryDisabled: css`
+    ${buttonDefaultCSS.basicCss};
+    background: ${({ theme }) => theme.colors.grey7};
+    color: ${({ theme }) => theme.colors.grey2};
+  `,
 };
 
 const ButtonWrapper = styled.button<{ $type: string }>`
@@ -126,6 +131,8 @@ const ButtonWrapper = styled.button<{ $type: string }>`
         return buttonCSS.tertiaryDisabled;
       case 'halfPrimaryDisabled':
         return buttonCSS.halfPrimaryDisabled;
+      case 'quaternaryDisabled':
+        return buttonCSS.quaternaryDisabled;
       default:
         return '';
     }

--- a/src/components/atomComponents/Button.tsx
+++ b/src/components/atomComponents/Button.tsx
@@ -51,12 +51,12 @@ const buttonCSS = {
     ${buttonDefaultCSS.basicCss};
     background: ${({ theme }) => theme.colors.grey7};
     width: 15.2rem;
-    color: ${({ theme }) => theme.colors.white};
+    color: ${({ theme }) => theme.colors.grey4};
   `,
   primaryDisabled: css`
     ${buttonDefaultCSS.basicCss};
     background: ${({ theme }) => theme.colors.grey7};
-    color: ${({ theme }) => theme.colors.white};
+    color: ${({ theme }) => theme.colors.grey4};
   `,
   secondaryActive: css`
     ${buttonDefaultCSS.basicCss};

--- a/src/components/atomComponents/PasswordInput.tsx
+++ b/src/components/atomComponents/PasswordInput.tsx
@@ -85,6 +85,9 @@ const StyledPasswordInput = styled.input<{ $iserror: boolean }>`
 
   color: ${({ theme }) => theme.colors.white};
   font-size: ${({ theme }) => theme.fonts.body3};
+  &::placeholder {
+    color: ${({ theme }) => theme.colors.grey4};
+  }
 
   &:focus {
     border: 2px solid ${({ $iserror, theme }) => ($iserror ? theme.colors.red : theme.colors.main1)};

--- a/src/components/atomComponents/TextInput.tsx
+++ b/src/components/atomComponents/TextInput.tsx
@@ -84,6 +84,9 @@ const StyledTextInput = styled.input<{ $iserror: boolean }>`
   font-size: ${({ theme }) => theme.fonts.body3};
 
   caret-color: ${({ theme }) => theme.colors.main1};
+  &::placeholder{
+    color:${({theme})=>theme.colors.grey4}
+  }
 
   &:focus {
     outline: none;

--- a/src/pages/LoginEntrance/components/HostComponent.tsx
+++ b/src/pages/LoginEntrance/components/HostComponent.tsx
@@ -116,7 +116,7 @@ function HostComponent({ hostInfo, setHostInfo }: HostProps) {
       <StyledBtnSection>
         <Button
           typeState={
-            hostInfo.name && hostInfo.password.length >= 4 ? 'primaryActive' : 'secondaryDisabled'
+            hostInfo.name && hostInfo.password.length >= 4 ? 'primaryActive' : 'primaryDisabled'
           }
           onClick={hostInfo.name && hostInfo.password.length >= 4 ? loginHost : undefined}
         >

--- a/src/pages/SteppingStone/components/SteppingBtnSection.tsx
+++ b/src/pages/SteppingStone/components/SteppingBtnSection.tsx
@@ -1,12 +1,10 @@
-import { useEffect, useState, useTransition } from 'react';
+import { useEffect, useState } from 'react';
 
-import { userNameAtom } from 'atoms/atom';
 import Button from 'components/atomComponents/Button';
 import Text from 'components/atomComponents/Text';
 import CopyToClipboard from 'react-copy-to-clipboard';
 import { useParams } from 'react-router';
 import { Link, useLocation } from 'react-router-dom';
-import { useRecoilValue } from 'recoil';
 import styled from 'styled-components/macro';
 import { theme } from 'styles/theme';
 import { notify } from 'utils/toast/copyLink';
@@ -19,8 +17,11 @@ function SteppingBtnSection({ steppingType }: SteppingProps) {
   const location = useLocation();
   const meetInfo = { ...location.state };
   const { meetingId } = useParams();
-  const [isModalOpen, setIsModalOpen] = useState(true);
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
+  useEffect(()=>{
+    setIsModalOpen(true);
+  },[])
 
   return (
     <>
@@ -137,7 +138,7 @@ const ModalOverlay = styled.div<{$isModalOpen:boolean;}>`
   display:${({$isModalOpen})=>($isModalOpen?'block':'none')};
   position:fixed;
   top: 0;
-  /* transition: display 1s; display는 transition 불가 */
+
   background-color: rgba(0, 0, 0, 0.50);
   width:100%;
   height:100%;

--- a/src/pages/SteppingStone/components/SteppingBtnSection.tsx
+++ b/src/pages/SteppingStone/components/SteppingBtnSection.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useState, useTransition } from 'react';
+
 import { userNameAtom } from 'atoms/atom';
 import Button from 'components/atomComponents/Button';
 import Text from 'components/atomComponents/Text';
@@ -8,7 +10,6 @@ import { useRecoilValue } from 'recoil';
 import styled from 'styled-components/macro';
 import { theme } from 'styles/theme';
 import { notify } from 'utils/toast/copyLink';
-import ToastContainerBox from 'utils/toast/ToastContainer';
 
 interface SteppingProps {
   steppingType: string;
@@ -18,6 +19,8 @@ function SteppingBtnSection({ steppingType }: SteppingProps) {
   const location = useLocation();
   const meetInfo = { ...location.state };
   const { meetingId } = useParams();
+  const [isModalOpen, setIsModalOpen] = useState(true);
+
 
   return (
     <>
@@ -26,29 +29,27 @@ function SteppingBtnSection({ steppingType }: SteppingProps) {
           {
             meetComplete: (
               <>
-              <ModalOverlay>
-                <BottomSheetModal>
+                <BottomSheetModal $isModalOpen={isModalOpen}>
                   <BottomSheetDescription>
                   <Text font={'head2'} color={'white'}>회의방 링크가 생성되었어요!</Text>
                   <Text font={'title2'} color={`${theme.colors.grey4}`}>링크를 복사하여 팀원에게 공유해주세요</Text>
                   </BottomSheetDescription>
                   <CopyToClipboard text={`${import.meta.env.VITE_WEB_IP}/meet/${meetInfo.meetingId}`}>
-                    <Button typeState={'primaryActive'} onClick={notify}>
+                    <Button typeState={'primaryActive'} onClick={()=>setIsModalOpen(false)}>
                       <Text font={'button2'}>링크 복사하기</Text>
                     </Button>
                   </CopyToClipboard>
-                  <Link to={`/host/schedule/${meetInfo.meetingId}`}>
-                    <Button typeState={'primaryDisabled'}>
+                    <Button typeState={'primaryDisabled'} onClick={()=>setIsModalOpen(false)}>
                       <Text font={'button2'}>나중에 공유하기</Text>
                     </Button>
-                  </Link>
                 </BottomSheetModal>
-              </ModalOverlay>
-              {/* <Link to={`/host/schedule/${meetInfo.meetingId}`}>
+                <ModalOverlay $isModalOpen={isModalOpen} >
+                </ModalOverlay>
+                <Link to={`/host/schedule/${meetInfo.meetingId}`}>
                   <Button typeState={'primaryActive'}>
                     <Text font={'button2'}>나의 가능시간 입력</Text>
                   </Button>
-                </Link> */}
+                </Link>
               </>
             ),
             hostScheduleComplete: (
@@ -108,30 +109,35 @@ const StyledBtnSection = styled.section`
   justify-content: center;
   border-radius: 50%;
   width: 100%;
+  
 `;
 
-const BottomSheetModal = styled.div`
+const BottomSheetModal = styled.div<{$isModalOpen:boolean;}>`
   display:flex;
   position:fixed;
-  bottom:0;
+  bottom:${({$isModalOpen})=>$isModalOpen?0:-27.5}rem;
   flex-direction:column;
   gap:0.8rem;
-
+  transition: bottom 600ms cubic-bezier(0.86, 0, 0.07, 1);
+  z-index:1;
   border-top-left-radius: 1.2rem;
   border-top-right-radius: 1.2rem;
   background-color: ${({ theme }) => theme.colors.grey8};
 
   padding: 2.8rem 2rem 4rem;
-  width:100%; 
+  width:100%;
 
   & button {
     width:100%;
   }
+
 `
 
-const ModalOverlay = styled.div`
+const ModalOverlay = styled.div<{$isModalOpen:boolean;}>`
+  display:${({$isModalOpen})=>($isModalOpen?'block':'none')};
   position:fixed;
   top: 0;
+  /* transition: display 1s; display는 transition 불가 */
   background-color: rgba(0, 0, 0, 0.50);
   width:100%;
   height:100%;

--- a/src/pages/SteppingStone/components/SteppingBtnSection.tsx
+++ b/src/pages/SteppingStone/components/SteppingBtnSection.tsx
@@ -6,6 +6,7 @@ import { useParams } from 'react-router';
 import { Link, useLocation } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 import styled from 'styled-components/macro';
+import { theme } from 'styles/theme';
 import { notify } from 'utils/toast/copyLink';
 import ToastContainerBox from 'utils/toast/ToastContainer';
 
@@ -17,26 +18,37 @@ function SteppingBtnSection({ steppingType }: SteppingProps) {
   const location = useLocation();
   const meetInfo = { ...location.state };
   const { meetingId } = useParams();
-  console.log(meetingId);
+
   return (
     <>
-      {/* <ToastContainerBox /> */}
       <StyledBtnSection>
         {
           {
             meetComplete: (
               <>
-                {/* 이후 도메인 시 연결 */}
-                <CopyToClipboard text={`${import.meta.env.VITE_WEB_IP}/meet/${meetInfo.meetingId}`}>
-                  <Button typeState={'halfTertiaryActive'} onClick={notify}>
-                    <Text font={'button2'}>링크 복사하기</Text>
-                  </Button>
-                </CopyToClipboard>
-                <Link to={`/host/schedule/${meetInfo.meetingId}`}>
-                  <Button typeState={'halfPrimaryActive'}>
+              <ModalOverlay>
+                <BottomSheetModal>
+                  <BottomSheetDescription>
+                  <Text font={'head2'} color={'white'}>회의방 링크가 생성되었어요!</Text>
+                  <Text font={'title2'} color={`${theme.colors.grey4}`}>링크를 복사하여 팀원에게 공유해주세요</Text>
+                  </BottomSheetDescription>
+                  <CopyToClipboard text={`${import.meta.env.VITE_WEB_IP}/meet/${meetInfo.meetingId}`}>
+                    <Button typeState={'primaryActive'} onClick={notify}>
+                      <Text font={'button2'}>링크 복사하기</Text>
+                    </Button>
+                  </CopyToClipboard>
+                  <Link to={`/host/schedule/${meetInfo.meetingId}`}>
+                    <Button typeState={'primaryDisabled'}>
+                      <Text font={'button2'}>나중에 공유하기</Text>
+                    </Button>
+                  </Link>
+                </BottomSheetModal>
+              </ModalOverlay>
+              {/* <Link to={`/host/schedule/${meetInfo.meetingId}`}>
+                  <Button typeState={'primaryActive'}>
                     <Text font={'button2'}>나의 가능시간 입력</Text>
                   </Button>
-                </Link>
+                </Link> */}
               </>
             ),
             hostScheduleComplete: (
@@ -48,7 +60,6 @@ function SteppingBtnSection({ steppingType }: SteppingProps) {
                 </Link>
                 <CopyToClipboard
                   text={`${import.meta.env.VITE_WEB_IP}/meet/${meetingId}`}
-                  // onCopy={handleCopy}
                 >
                   <Button typeState={'halfPrimaryActive'} onClick={notify}>
                     <Text font={'button2'}>링크 복사하기</Text>
@@ -98,3 +109,38 @@ const StyledBtnSection = styled.section`
   border-radius: 50%;
   width: 100%;
 `;
+
+const BottomSheetModal = styled.div`
+  display:flex;
+  position:fixed;
+  bottom:0;
+  flex-direction:column;
+  gap:0.8rem;
+
+  border-top-left-radius: 1.2rem;
+  border-top-right-radius: 1.2rem;
+  background-color: ${({ theme }) => theme.colors.grey8};
+
+  padding: 2.8rem 2rem 4rem;
+  width:100%; 
+
+  & button {
+    width:100%;
+  }
+`
+
+const ModalOverlay = styled.div`
+  position:fixed;
+  top: 0;
+  background-color: rgba(0, 0, 0, 0.50);
+  width:100%;
+  height:100%;
+`
+
+const BottomSheetDescription = styled.div`
+  display:flex;
+  flex-direction:column;
+  gap:0.8rem;
+  margin-bottom:2.4rem;
+  padding-left:0.9rem;
+`

--- a/src/pages/SteppingStone/components/SteppingBtnSection.tsx
+++ b/src/pages/SteppingStone/components/SteppingBtnSection.tsx
@@ -40,7 +40,7 @@ function SteppingBtnSection({ steppingType }: SteppingProps) {
                       <Text font={'button2'}>링크 복사하기</Text>
                     </Button>
                   </CopyToClipboard>
-                    <Button typeState={'primaryDisabled'} onClick={()=>setIsModalOpen(false)}>
+                    <Button typeState={'quaternaryDisabled'} onClick={()=>setIsModalOpen(false)}>
                       <Text font={'button2'}>나중에 공유하기</Text>
                     </Button>
                 </BottomSheetModal>

--- a/src/pages/createMeeting/components/useFunnel/SetDates.tsx
+++ b/src/pages/createMeeting/components/useFunnel/SetDates.tsx
@@ -1,14 +1,14 @@
 // import { useState } from 'react';
 
+import './SetDates.css';
+
 import { methodStateAtom } from 'atoms/atom';
 import Button from 'components/atomComponents/Button';
 import Text from 'components/atomComponents/Text';
-import { MeetingInfo, FunnelProps } from 'pages/createMeeting/types/useFunnelInterface';
+import { FunnelProps, MeetingInfo } from 'pages/createMeeting/types/useFunnelInterface';
 import { Calendar, DateObject, getAllDatesInRange } from 'react-multi-date-picker';
 import { useRecoilState } from 'recoil';
 import styled from 'styled-components/macro';
-
-import './SetDates.css';
 
 const months = [
   '1월',
@@ -125,7 +125,7 @@ function SetDates({ meetingInfo, setMeetingInfo, setStep }: FunnelProps) {
               meetingInfo.availableDates.length > 0 &&
               meetingInfo.availableDates.length < 8)
               ? 'primaryActive'
-              : 'secondaryDisabled'
+              : 'primaryDisabled'
           }
           onClick={
             (meetingInfo.availableDates.length > 1 && meetingInfo.availableDates.length < 8) ||

--- a/src/pages/createMeeting/components/useFunnel/SetDuration.tsx
+++ b/src/pages/createMeeting/components/useFunnel/SetDuration.tsx
@@ -1,7 +1,7 @@
 import Button from 'components/atomComponents/Button';
 import Text from 'components/atomComponents/Text';
 import { durationType } from 'pages/createMeeting/data/meetingInfoData';
-import { MeetingInfo, FunnelProps } from 'pages/createMeeting/types/useFunnelInterface';
+import { FunnelProps, MeetingInfo } from 'pages/createMeeting/types/useFunnelInterface';
 import styled from 'styled-components/macro';
 
 function SetDuration({ meetingInfo, setMeetingInfo, setStep }: FunnelProps) {
@@ -13,9 +13,7 @@ function SetDuration({ meetingInfo, setMeetingInfo, setStep }: FunnelProps) {
             <Button
               key={i + duration.enum}
               typeState={
-                meetingInfo.duration === duration.enum
-                  ? `halfPrimaryActive`
-                  : `halfsecondaryDisabled`
+                meetingInfo.duration === duration.enum ? `halfPrimaryActive` : `halfPrimaryDisabled`
               }
               onClick={() => {
                 setMeetingInfo((prev: MeetingInfo) => {
@@ -30,7 +28,7 @@ function SetDuration({ meetingInfo, setMeetingInfo, setStep }: FunnelProps) {
       </DurationWrapper>
       <StyledBtnWrapper>
         <Button
-          typeState={meetingInfo.duration ? 'primaryActive' : 'secondaryDisabled'}
+          typeState={meetingInfo.duration ? 'primaryActive' : 'primaryDisabled'}
           onClick={
             meetingInfo.duration
               ? () =>

--- a/src/pages/createMeeting/components/useFunnel/SetHostInfo.tsx
+++ b/src/pages/createMeeting/components/useFunnel/SetHostInfo.tsx
@@ -4,7 +4,7 @@ import Button from 'components/atomComponents/Button';
 import PasswordInput from 'components/atomComponents/PasswordInput';
 import Text from 'components/atomComponents/Text';
 import TextInput from 'components/atomComponents/TextInput';
-import { MeetingInfo, FunnelProps } from 'pages/createMeeting/types/useFunnelInterface';
+import { FunnelProps, MeetingInfo } from 'pages/createMeeting/types/useFunnelInterface';
 import styled from 'styled-components/macro';
 import { theme } from 'styles/theme';
 
@@ -75,7 +75,7 @@ function SetHostInfo({ meetingInfo, setMeetingInfo, setStep }: FunnelProps) {
           typeState={
             meetingInfo.name && meetingInfo.password.length >= 4
               ? 'primaryActive'
-              : 'secondaryDisabled'
+              : 'primaryDisabled'
           }
           onClick={
             meetingInfo.name && meetingInfo.password.length >= 4

--- a/src/pages/createMeeting/components/useFunnel/SetPlace.tsx
+++ b/src/pages/createMeeting/components/useFunnel/SetPlace.tsx
@@ -16,7 +16,7 @@ function SetPlace({ meetingInfo, setMeetingInfo, setStep }: FunnelProps) {
           return (
             <PlaceSection key={i + type}>
               <Button
-                typeState={meetingInfo.place === type ? 'primaryActive' : 'secondaryDisabled'}
+                typeState={meetingInfo.place === type ? 'primaryActive' : 'primaryDisabled'}
                 onClick={() => setPlaceDetail(type)}
               >
                 <Text font={'button2'}>
@@ -41,7 +41,7 @@ function SetPlace({ meetingInfo, setMeetingInfo, setStep }: FunnelProps) {
       </PlaceInfoSection>
       <StyledBtnSection>
         <Button
-          typeState={meetingInfo.place ? 'primaryActive' : 'secondaryDisabled'}
+          typeState={meetingInfo.place ? 'primaryActive' : 'primaryDisabled'}
           onClick={
             meetingInfo.place
               ? () =>

--- a/src/pages/createMeeting/components/useFunnel/SetTimes.tsx
+++ b/src/pages/createMeeting/components/useFunnel/SetTimes.tsx
@@ -1,9 +1,9 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 import Button from 'components/atomComponents/Button';
 import Text from 'components/atomComponents/Text';
-import { DropUpIc, DropDownIc, Wave } from 'components/Icon/icon';
-import { preferTimeType, directInputButton } from 'pages/createMeeting/data/meetingInfoData';
+import { DropDownIc, DropUpIc, Wave } from 'components/Icon/icon';
+import { directInputButton, preferTimeType } from 'pages/createMeeting/data/meetingInfoData';
 import { FunnelProps, PreferTimeInfo } from 'pages/createMeeting/types/useFunnelInterface';
 import styled from 'styled-components/macro';
 
@@ -176,7 +176,7 @@ function SetTimes({ meetingInfo, setMeetingInfo, setStep }: FunnelProps) {
             meetingInfo.preferTimes[0].startTime &&
             meetingInfo.preferTimes[0].endTime !== '00:00'
               ? 'primaryActive'
-              : 'secondaryDisabled'
+              : 'primaryDisabled'
           }
           onClick={
             meetingInfo.preferTimes.length >= 1 &&

--- a/src/pages/createMeeting/components/useFunnel/SetTitle.tsx
+++ b/src/pages/createMeeting/components/useFunnel/SetTitle.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import Button from 'components/atomComponents/Button';
 import Text from 'components/atomComponents/Text';
 import TextInput from 'components/atomComponents/TextInput';
-import { MeetingInfo, FunnelProps } from 'pages/createMeeting/types/useFunnelInterface';
+import { FunnelProps, MeetingInfo } from 'pages/createMeeting/types/useFunnelInterface';
 import styled from 'styled-components/macro';
 
 function SetTitle({ meetingInfo, setMeetingInfo, setStep }: FunnelProps) {
@@ -29,9 +29,7 @@ function SetTitle({ meetingInfo, setMeetingInfo, setStep }: FunnelProps) {
       <StyledBtnSection>
         <Button
           typeState={
-            meetingInfo.title && meetingInfo.title.length < 16
-              ? 'primaryActive'
-              : 'secondaryDisabled'
+            meetingInfo.title && meetingInfo.title.length < 16 ? 'primaryActive' : 'primaryDisabled'
           }
           onClick={
             meetingInfo.title && meetingInfo.title.length < 16


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label, Milestone 붙이기 --> 

### ✨ #219  ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->

### todo 
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->
- [x] 바텀시트 모달 디자인
- [x] 첫 렌더링시 아래에서 올라오는 애니메이션 
- [x] 링크 복사 기능
- [x] 링크 복사 또는 나중에 공유하기 버튼 누른 후 내려가는 애니메이션

## 📌 내가 알게 된 부분
<!-- 새롭게 알게 된 부분을 적기 (기록하면서 개발하기!) -->
- 모달에 애니메이션을 부여하기 위해서 transition을 사용해야하는데, 이 transition이 안먹어서 진짜 애를 썼어요...
  우선 제가 처음에 모달 부분을 다음과 같이 구조를 짰는데요. 참고로 ModalOverlay는 모달 뒤에 깔리는 불투명한 검정색 배경입니다.
  ```html
  <ModalOverlay>
    <BottomSheetModal>
    </BottomSheetModal>
  </ModalOverlay>
  ```
  이렇게 ModalOverlay로 모달을 감싸놓고, useState로 `isModalOpen` state를 만들어서 state가 바뀔 때마다 ModalOverlay는 position:display와 none을 왔다갔다하고(모달이 없어지면 오버레이도 없어져야하니), BottomSheetModal은 position:fixed; 상태에서 bottom 값을 바꿈으로써 아래에서 위로 올라오도록 위치를 변경했어요. 그 상태에서 transition을 적용하면 아래에서 위로 올라오는 애니메이션이 적용되어야하는데 아무리해도 적용이 안되는겁니다!! ㅠㅠ
- 그래서 처음에는, useState가 변경되는 것과 style이 변경되는 것에 무언가 시간차를 주어야 한다고 생각했어요. 왜냐면 바닐라 자스로 할 때는 실제로 돔 잡아서 style 조작할 때 setTimeout을 주어야 transition 되는 것이 눈에 보이거든요... 그래서 setTimeout도 써보고, 모달 위치 저장하는 state하나를 더 만들어서 useEffect로 조작해보고, [useTransition](https://velog.io/@ktthee/React-18-%EC%97%90-%EC%B6%94%EA%B0%80%EB%90%9C-useDeferredValue-%EB%A5%BC-%EC%8D%A8-%EB%B3%B4%EC%9E%90)도 써보고 별별 난리를 쳤는데 아무리해도 안되는 것이었죠.
- 내내 이상했던 점은, 개발자도구 상에서 BottomSheetModal의 위치를 변경해보면 transition이 제대로 적용되어 스윽~스윽~하고 움직인다는 점이었습니다. transition이 적용이 안된 상황은 아니었던거죠.
- 그래서 문제원인을 밖에서 찾아보니 아뿔싸! `isModalOpen` state값에 따라서 ModalOverlay 컴포넌트의 position을 display<->none 으로 토글하고 있었던 것 때문이었습니다! ModalOverlay는 BottomSheetModal의 부모요소인데, ModalOverlay가 display<->none으로 깜빡거리면, 즉 요소가 돔에서 아예 없어졌다 나타났다 하면 그에 따라 자식요소인 BottomSheetModal도 `isModalOpen` 값에 따라 없어졌다 나타났다 할 것이고, 그래서 transition이 보일 새도 없이 그저 돔에서 제거될뿐이었던 겁니다...
-  따라서 다음과 같이 구조를 바꿨습니다. 그러면 더이상 ModalOverlay가 있었다 없었다해도 BottomSheetModal이 이에 영향받지 않고 애니메이션을 보여줄 수 있습니다.
    ```html
    <BottomSheetModal>
    </BottomSheetModal>
    <ModalOverlay>
    </ModalOverlay>
    ```

## 📌 공유하고 싶은 부분
<!-- 새롭게 알게 된 부분을 적기 (기록하면서 개발하기!) -->
- 모달.. 여러번 만들어도 왜 자꾸 헷갈리는걸까요? 이번 기회로 모달을 제작하는 저만의 방법론(?)을 정립할 수 있었습니다.
  1. 모달 컨텐츠와 모달 오버레이를 형제 요소로 둔다.
  2. 모달 컨텐츠와 모달 오버레이 모두 position:fixed;로 한다.
  3. 모달 오버레이는 width 100% height 100%로 하고 배경색 채우면 끝이다.
  4. 모달 컨텐츠는 top right left bottom 값을 활용하여 위치값을 조정한다.
  5. 이렇게하면 모달 오버레이가 모달 컨텐츠보다 위에있게 된다. 따라서 모달 컨텐츠에 z-index값을 추가하여 위로 올라오도록 한다.
 
- css transition 속성에 대해 고민해본 적 있나요? transition은 어떠한 css 속성이 변화할 때, 이것이 일정 시간(duration)에 걸쳐 일어나도록 하는 것인데요. 예를들어 hover시에 글자 색상이 바뀌게 했는데 여기에 `transition:color 1s;` 을 적용하면 글자 색상의 변화가 1s라는 시간에 걸쳐서 서서히 발생하게 하는 것이죠. 그렇다면 [animatable css property](https://udn.realityripple.com/docs/Web/CSS/CSS_animated_properties)에 대해 생각해본 적이 있나요? 즉, transition이 어떤 속성에나 먹히진 않는다는 거예요. '서서히 바뀔 수 있는' 속성에만 적용할 수 있죠. 예를들어, display 속성에는 transition을 적용할 수 없습니다. display:none 과 flex를 서서히 변화시킬 수는 없는거예요.

## 📌 질문할 부분 
<!-- 작은 거라도 좋아요! (같이 성장하기)  -->
- 현재 코드에서, `isModalOpen` 상태값이 false로 초기화되어있다가 useEffect를 통해서 첫 렌더링시에 이를 true로 바꿈으로서, 이 페이지에 처음 접속했을 때 모달이 아래에서 위로 올라오는 애니메이션이 적용되도록 구현했어요. 그런데 모달 뒤에 오버레이의 유무 또한 `isModalOpen`값에 의존하다 보니, 이 페이지에 딱 처음 접속했을 때 아주 잠깐동안 overlay가 없다가 모달이 올라오면서 overlay가 생기거든요. 즉 첫 렌더링이 되면서 overlay가 생기는데, 약간의 딜레이가 있어서 살짝 깜빡거리는 느낌이 나는거예요. 아 이거 참 말로 설명하기 어렵네요. 영상으로 보면 이해가 되실까요?

https://github.com/ASAP-as-soon-as-possible/ASAP_Client/assets/55528304/ebc1f5a2-cb52-4b18-9ca3-54ce91fcd2a0

보이나요!! 딱 처음 페이지 들어갔을때 오버레이가 살짝 깜빡이는거 보이나요!! ㅠㅠ 이거 너무 거슬리는데 어떻게 해결하면 좋을지 고민이네요...
