### PR TITLE
fix: /time POST 요청값에서 id와 dayOfWeek 필드 삭제, month와 day에서 padStart 삭제

### DIFF
--- a/src/pages/selectSchedule/utils/changeApiReq.ts
+++ b/src/pages/selectSchedule/utils/changeApiReq.ts
@@ -13,13 +13,11 @@ export const transformHostScheduleType = (
     if (!matchedResult) {
       return null; // Handle the case when there is no match for the date pattern
     }
-    const [, month, day, dateOfWeek] = matchedResult;
+    const [, month, day, ,] = matchedResult;
 
     return {
-      id: item.id.toString(),
-      month: month.padStart(2, '0'),
-      day: day.padStart(2, '0'),
-      dayOfWeek: dateOfWeek,
+      month: month,
+      day: day,
       startTime: item.startTime,
       endTime: item.endTime,
       priority: item.priority,

--- a/src/pages/selectSchedule/utils/changeApiReq.ts
+++ b/src/pages/selectSchedule/utils/changeApiReq.ts
@@ -35,7 +35,6 @@ export const transformUserScheduleType = (
       // Handle the case when there is no match for the date pattern
       // For example, you can return an empty object or any default value you prefer.
       return {
-        id: '',
         month: '',
         day: '',
         dayOfWeek: '',
@@ -47,12 +46,10 @@ export const transformUserScheduleType = (
     // const [, month, day, dateOfWeek]: string[] | null = item.date.match(
     //   /(\d+)월 (\d+)일 \((\S+)\)/,
     // );
-    const [, month, day, dateOfWeek] = matchedResult;
+    const [, month, day, ,] = matchedResult;
     return {
-      id: item.id.toString(),
-      month: month.padStart(2, '0'),
-      day: day.padStart(2, '0'),
-      dayOfWeek: dateOfWeek,
+      month: month,
+      day: day,
       startTime: item.startTime,
       endTime: item.endTime,
       priority: item.priority,

--- a/src/types/createAvailableSchduleType.ts
+++ b/src/types/createAvailableSchduleType.ts
@@ -1,8 +1,6 @@
 export interface HostAvailableSchduleRequestType {
-  id: string;
   month: string;
   day: string;
-  dayOfWeek: string;
   startTime: string;
   endTime: string;
   priority: number;

--- a/src/types/createAvailableSchduleType.ts
+++ b/src/types/createAvailableSchduleType.ts
@@ -17,10 +17,8 @@ export interface HostAvailableScheduleResponseType {
 export interface UserAvailableScheduleRequestType {
   name: string;
   availableTimes: {
-    id: string;
     month: string;
     day: string;
-    dayOfWeek: string;
     startTime: string;
     endTime: string;
     priority: number;


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label, Milestone 붙이기 --> 

### ✨ 해당 이슈 번호 ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
#247 

### todo 
/time POST (시간 입력)시에 서버에게 전달했던 id, dayOfWeek 필드가 필요없어서 이를 삭제하고, month와 day에 대해 자릿수 채움이 필요 없도록 통일하게됨에 따라 padStart() 메소드를 삭제함.

### 기존
```ts
id: item.id.toString(),
month: month.padStart(2, '0'),
day: day.padStart(2, '0'),
dayOfWeek: dateOfWeek,
startTime: item.startTime,
endTime: item.endTime,
priority: item.priority,
```

### 변경 후
```ts
month: month,
day: day,
startTime: item.startTime,
endTime: item.endTime,
priority: item.priority,
```

## 📌스크린샷
### 방장 입력
![image](https://github.com/ASAP-as-soon-as-possible/ASAP_Client/assets/55528304/593b8ba9-8990-4d25-b250-5c606ed847e6)
### 멤버 입력
![image](https://github.com/ASAP-as-soon-as-possible/ASAP_Client/assets/55528304/63e798f2-61d8-4b02-bdf1-12e62a7f6d6d)
