### PR TITLE
[Feat/#250] 탭투탭에서 블록이 겹쳐서 쌓이는 문제 해결

### DIFF
--- a/src/pages/OverallSchedule/components/OverallScheduleTable.tsx
+++ b/src/pages/OverallSchedule/components/OverallScheduleTable.tsx
@@ -21,7 +21,7 @@ function OverallScheduleTable({
   availableDates,
   dataOverallSchedule,
 }: OverallScheduleTableProps) {
-  const [clickedSlot, setClickedSlot] = useState<string | undefined>(undefined);
+  const [clickedSlot, setClickedSlot] = useState<string | null>(null);
   const [clickedUserNames, setClickedUserNames] = useState<string[]>([]);
 
   const getAvailableTimesPerDate = (

--- a/src/pages/OverallSchedule/contexts/useClickContext.ts
+++ b/src/pages/OverallSchedule/contexts/useClickContext.ts
@@ -1,15 +1,15 @@
 import { Dispatch, SetStateAction, createContext, useContext } from 'react';
 
 interface ClickContextType {
-  clickedSlot: string | undefined;
+  clickedSlot: string | null;
   setClickedSlot: Dispatch<SetStateAction<ClickContextType['clickedSlot']>>;
   clickedUserNames: string[];
   setClickedUserNames: Dispatch<SetStateAction<ClickContextType['clickedUserNames']>>;
 }
 
 export const ClickContext = createContext<ClickContextType>({
-  clickedSlot: undefined,
-  setClickedSlot: () => undefined,
+  clickedSlot: null,
+  setClickedSlot: () => null,
   clickedUserNames: [],
   setClickedUserNames: () => [],
 });

--- a/src/pages/selectSchedule/components/SelectScheduleTable.tsx
+++ b/src/pages/selectSchedule/components/SelectScheduleTable.tsx
@@ -13,7 +13,7 @@ import { SelectContext, SelectedSlotType } from '../contexts/useSelectContext';
 import { StepSlotsType, StepbottomItemsType } from '../types';
 
 function SelectScheduleTable({ timeSlots, availableDates }: TimetableStructure) {
-  const [startSlot, setStartSlot] = useState<string | undefined>(undefined);
+  const [startSlot, setStartSlot] = useState<string | null>(null);
   const [selectedSlots, setSelectedSlots] = useState<SelectedSlotType>({});
 
   const { scheduleStep } = useScheduleStepContext();

--- a/src/pages/selectSchedule/components/selectTimeSlot/hooks/useSlotSelection.ts
+++ b/src/pages/selectSchedule/components/selectTimeSlot/hooks/useSlotSelection.ts
@@ -28,7 +28,7 @@ const useSlotSeletion = () => {
       });
       removeOverlappedSlots(endSlot, dateOfStartSlot);
     }
-    setStartSlot(undefined);
+    setStartSlot(null);
   };
 
   const handleDeleteSlot = (selectedEntryId: number) => {
@@ -62,11 +62,11 @@ const useSlotSeletion = () => {
 
   const onClickSlot = (targetSlot: string, selectedEntryId?: number) => {
     if (selectedEntryId !== undefined) {
-      if (startSlot === undefined) {
+      if (startSlot === null) {
         handleDeleteSlot(selectedEntryId);
       }
-      setStartSlot(undefined);
-    } else if (startSlot !== undefined) {
+      setStartSlot(null);
+    } else if (startSlot !== null) {
       handleCompleteSlot(targetSlot);
     } else {
       handleSelectSlot(targetSlot);

--- a/src/pages/selectSchedule/components/selectTimeSlot/hooks/useSlotSelection.ts
+++ b/src/pages/selectSchedule/components/selectTimeSlot/hooks/useSlotSelection.ts
@@ -40,10 +40,11 @@ const useSlotSeletion = () => {
   };
 
   const removeOverlappedSlots = (endSlot: string, dateOfStartSlot: string) => {
-    const selectedSlotsPerDate = Object.fromEntries(
-      Object.entries(selectedSlots).filter(([, slot]) => slot.date === dateOfStartSlot),
+    const selectedSlotsPerDate = Object.entries(selectedSlots).filter(
+      ([, slot]) => slot.date === dateOfStartSlot,
     );
-    Object.entries(selectedSlotsPerDate).forEach(
+
+    selectedSlotsPerDate.forEach(
       ([id, { startSlot: selectedStartSlot, endSlot: selectedEndSlot }]) => {
         const startSlotTime = startSlot && startSlot.split('/').pop();
         const endSlotTime = endSlot.split('/').pop();

--- a/src/pages/selectSchedule/components/selectTimeSlot/hooks/useSlotSelection.ts
+++ b/src/pages/selectSchedule/components/selectTimeSlot/hooks/useSlotSelection.ts
@@ -21,23 +21,25 @@ const useSlotSeletion = () => {
       const keys = Object.keys(selectedSlots).map(Number);
       const newKey = keys.length ? Math.max(...keys) + 1 : 0;
 
-      const newSelectedSlots = { ...removeOverlappedSlots(endSlot, dateOfStartSlot) };
-
-      newSelectedSlots[newKey] = newSelectedSlot;
-      setSelectedSlots(newSelectedSlots);
+      setSelectedSlots((prev) => {
+        const newSelectedSlots = { ...prev };
+        newSelectedSlots[newKey] = newSelectedSlot;
+        return newSelectedSlots;
+      });
+      removeOverlappedSlots(endSlot, dateOfStartSlot);
     }
     setStartSlot(undefined);
   };
 
   const handleDeleteSlot = (selectedEntryId: number) => {
-    const newSelectedSlots = { ...selectedSlots };
-    delete newSelectedSlots[selectedEntryId];
-    setSelectedSlots(newSelectedSlots);
+    setSelectedSlots((prev) => {
+      const newSelectedSlots = { ...prev };
+      delete newSelectedSlots[selectedEntryId];
+      return newSelectedSlots;
+    });
   };
 
   const removeOverlappedSlots = (endSlot: string, dateOfStartSlot: string) => {
-    const newSelectedSlots = { ...selectedSlots };
-
     const selectedSlotsPerDate = Object.fromEntries(
       Object.entries(selectedSlots).filter(([, slot]) => slot.date === dateOfStartSlot),
     );
@@ -51,11 +53,10 @@ const useSlotSeletion = () => {
           selectedStartSlot > startSlotTime &&
           selectedEndSlot < endSlotTime
         ) {
-          delete newSelectedSlots[parseInt(id)];
+          handleDeleteSlot(Number(id));
         }
       },
     );
-    return newSelectedSlots;
   };
 
   const onClickSlot = (targetSlot: string, selectedEntryId?: number) => {

--- a/src/pages/selectSchedule/components/selectTimeSlot/hooks/useSlotSelection.ts
+++ b/src/pages/selectSchedule/components/selectTimeSlot/hooks/useSlotSelection.ts
@@ -46,13 +46,13 @@ const useSlotSeletion = () => {
 
     selectedSlotsPerDate.forEach(
       ([id, { startSlot: selectedStartSlot, endSlot: selectedEndSlot }]) => {
-        const startSlotTime = startSlot && startSlot.split('/').pop();
-        const endSlotTime = endSlot.split('/').pop();
+        const currentStartSlotTime = startSlot && startSlot.split('/').pop();
+        const currentEndSlotTime = endSlot.split('/').pop();
         if (
-          startSlotTime &&
-          endSlotTime &&
-          selectedStartSlot > startSlotTime &&
-          selectedEndSlot < endSlotTime
+          currentStartSlotTime &&
+          currentEndSlotTime &&
+          selectedStartSlot > currentStartSlotTime &&
+          selectedEndSlot < currentEndSlotTime
         ) {
           handleDeleteSlot(Number(id));
         }

--- a/src/pages/selectSchedule/contexts/useScheduleStepContext.ts
+++ b/src/pages/selectSchedule/contexts/useScheduleStepContext.ts
@@ -9,7 +9,7 @@ interface ScheduleStepContextType {
 
 export const ScheduleStepContext = createContext<ScheduleStepContextType>({
   scheduleStep: 'selectTimeSlot',
-  setScheduleStep: () => undefined,
+  setScheduleStep: () => null,
 });
 
 export function useScheduleStepContext() {

--- a/src/pages/selectSchedule/contexts/useSelectContext.ts
+++ b/src/pages/selectSchedule/contexts/useSelectContext.ts
@@ -12,17 +12,17 @@ export interface SelectedSlotType {
 }
 
 interface SelectContextType {
-  startSlot: string | undefined;
+  startSlot: string | null;
   setStartSlot: Dispatch<SetStateAction<SelectContextType['startSlot']>>;
   selectedSlots: SelectedSlotType;
   setSelectedSlots: Dispatch<SetStateAction<SelectedSlotType>>;
 }
 
 export const SelectContext = createContext<SelectContextType>({
-  startSlot: undefined,
-  setStartSlot: () => undefined,
+  startSlot: null,
+  setStartSlot: () => null,
   selectedSlots: {},
-  setSelectedSlots: () => undefined,
+  setSelectedSlots: () => null,
 });
 
 export function useSelectContext() {

--- a/src/pages/selectSchedule/utils/changeApiReq.ts
+++ b/src/pages/selectSchedule/utils/changeApiReq.ts
@@ -1,9 +1,8 @@
+import { ScheduleStates } from 'pages/legacy/selectSchedule/types/Schedule';
 import {
   HostAvailableSchduleRequestType,
   UserAvailableScheduleRequestType,
 } from 'src/types/createAvailableSchduleType';
-
-import { ScheduleStates } from '../types/Schedule';
 
 export const transformHostScheduleType = (
   scheduleList: ScheduleStates[],


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 🌀 해당 이슈 번호

- close #250

## 🔹 어떤 것을 변경했나요?

- [x] 블록이 겹쳐서 쌓일 경우, 더 작은 블록을 삭제함

## 🔹 어떻게 구현했나요?
탭투탭 로직을 관할하는 `useSlotSelection.ts`에서 `removeOverlappedSlots`라는 새로운 함수를 추가했습니다.
```ts
  // 현재 선택한 '탭투탭'의 종료시간(endSlot)과 그 시간이 속하는 날짜(dateOfStartSlot)을 받아옵니다.
  // 시작시간(startSlot)은 context로 관리되고 있기 때문에 인자로 넘겨줄 필요가 없습니다.
  const removeOverlappedSlots = (endSlot: string, dateOfStartSlot: string) => {
    const selectedSlotsPerDate = Object.fromEntries(
      Object.entries(selectedSlots).filter(([, slot]) => slot.date === dateOfStartSlot),
    );  // 선택된 블록들 중 현재 선택한 탭투탭과 같은 날짜인 것만 필터링합니다. (다른 날짜에 속하는 블록은 확인할 필요없음)

    Object.entries(selectedSlotsPerDate).forEach( // 같은 날짜의 블록들을 탐색하면서...
      ([id, { startSlot: selectedStartSlot, endSlot: selectedEndSlot }]) => {
        const startSlotTime = startSlot && startSlot.split('/').pop();
        const endSlotTime = endSlot.split('/').pop();
        if (
          startSlotTime &&
          endSlotTime &&
          selectedStartSlot > startSlotTime && // 지금 선택한 시작시간보다 후에 시작하고
          selectedEndSlot < endSlotTime // 지금 선택한 종료시간보다 일찍 끝난다면
          // 이 조건을 만족하면, 지금 선택한 블록과 겹치면서 더 작은 범위의 블록이므로 제거해야 합니다.
        ) {
          handleDeleteSlot(Number(id)); // 제거합니다.
        }
      },
    );
  };
```

그리고 이 함수를, 새로운 블록을 만드는 함수인 `handleCompleteSlot` 함수에서 사용합니다.

```ts
const handleCompleteSlot = (endSlot: string) => {
    const dateOfStartSlot = startSlot && startSlot.substring(0, startSlot.lastIndexOf('/'));
    const dateOfEndSlot = endSlot.substring(0, endSlot.lastIndexOf('/'));
    if (startSlot && dateOfStartSlot === dateOfEndSlot) {
      const newSelectedSlot = {
        date: dateOfStartSlot,
        startSlot: startSlot && startSlot.substring(startSlot.lastIndexOf('/') + 1),
        endSlot: endSlot.substring(endSlot.lastIndexOf('/') + 1),
        priority: 0,
      };

      const keys = Object.keys(selectedSlots).map(Number);
      const newKey = keys.length ? Math.max(...keys) + 1 : 0;

      setSelectedSlots((prev) => {
        const newSelectedSlots = { ...prev };
        newSelectedSlots[newKey] = newSelectedSlot;
        return newSelectedSlots;
      });
      removeOverlappedSlots(endSlot, dateOfStartSlot); // ⬅️ here!
      // 새로운 블럭을 생성한 후에, 그 블럭과 겹치면서 더 작은 범위에 있는 블럭을 제거합니다.
    }
    setStartSlot(undefined);
  };
```

## 🔹 PR 포인트를 알려주세요!
`handleCompleteSlot()`에서 setState로 상태를 업데이트하고, 그 다음에 호출하는 `removeOverlappedSlots()`에서도 `handleDeleteSlot()`를 호출하여 setState로 상태를 업데이트하게 됩니다. setState를 연달아 사용하게 되면 state가 의도한대로 동기적으로 업데이트되지 않습니다. React의 batching 방식으로 인해, state는 리렌더링 후에 한꺼번에 변경되기 때문입니다. [관련하여 이해를 도울 아티클](https://velog.io/@dongjun187/React%EC%9D%98-setState%EB%8A%94-%EB%B9%84%EB%8F%99%EA%B8%B0%EB%8B%A4)

따라서 기존 방식에서 prev인자를 통해 updater함수를 전달하는 방식으로 변경하여 해결할 수 있었습니다.
(커밋메시지를 잘못 적었어요 ㅠㅠ `batching 방식으로 변경`이 아니라 `updater함수 방식으로 변경` 입니다)

## 🔹 스크린샷을 남겨주세요!

https://github.com/ASAP-as-soon-as-possible/ASAP_Client/assets/55528304/5db232e2-b07e-4f04-ab2b-19f3c0b7e126

오른쪽 devtool 창에서 `selectedSlots`값이 변경되는 모습을 보면 동작을 더 쉽게 이해할 수 있습니다!
