### PR TITLE
[feat/#252] 이미 확정된 회의의 시간표를 조회하면 큐카드로 이동

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -1,5 +1,3 @@
-import { BrowserRouter, Route, Routes } from 'react-router-dom';
-
 import ChooseBestTime from 'pages/bestMeetTime/ChooseBestTime';
 import CreateMeeting from 'pages/createMeeting/CreateMeeting';
 import CueCard from 'pages/cueCard/CueCard';
@@ -7,10 +5,9 @@ import ErrorPage404 from 'pages/errorLoading/ErrorPage404';
 import LoadingPage from 'pages/errorLoading/LoadingPage';
 import LoginEntrance from 'pages/loginEntrance/LoginEntrance';
 import OnBoarding from 'pages/onBoarding/OnBoarding';
-import SelectPage from 'pages/legacy/selectSchedule/SelectSchedulePage';
 import SelectSchedule from 'pages/selectSchedule/SelectSchedule';
-import SelectSchedulePriority from 'pages/legacy/selectSchedule/SelectPriorityPage';
 import SteppingLayout from 'pages/steppingStone/SteppingLayout';
+import { BrowserRouter, Route, Routes } from 'react-router-dom';
 
 const Router = () => {
   return (

--- a/src/pages/LoginEntrance/components/HostComponent.tsx
+++ b/src/pages/LoginEntrance/components/HostComponent.tsx
@@ -71,9 +71,7 @@ function HostComponent({ hostInfo, setHostInfo }: HostProps) {
             console.log(err.response.data.message);
             setIsModalOpen(true);
           } else {
-            console.log(err.response.status);
-            console.log(err.response.data.message);
-            navigate('/error');
+            navigate(`/q-card/${meetingId}`);
           }
         }
       }

--- a/src/utils/apis/useGetTimetable.ts
+++ b/src/utils/apis/useGetTimetable.ts
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 
 import { useQuery } from '@tanstack/react-query';
-import { AxiosError, isAxiosError } from 'axios';
+import { isAxiosError } from 'axios';
 import { DURATION, PLACE } from 'pages/selectSchedule/utils';
 import { useNavigate } from 'react-router-dom';
 

--- a/src/utils/apis/useGetTimetable.ts
+++ b/src/utils/apis/useGetTimetable.ts
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 
 import { useQuery } from '@tanstack/react-query';
-import { isAxiosError } from 'axios';
+import { AxiosError, isAxiosError } from 'axios';
 import { DURATION, PLACE } from 'pages/selectSchedule/utils';
 import { useNavigate } from 'react-router-dom';
 
@@ -31,19 +31,15 @@ const getTimetable = async (meetingId: string) => {
   try {
     const res = await client.get<getTimetableResponse>(`/meeting/${meetingId}/schedule`);
     return res.data.data;
-  } catch (err) {
-    if (isAxiosError(err) && err.response) {
-      const errCode = err.response.status;
-      throw { errCode };
+  } catch (error) {
+    if (isAxiosError(error) && error.response) {
+      throw error;
     } else {
       throw new Error('알 수 없는 오류가 발생했습니다.');
     }
   }
 };
 
-interface ErrorType extends Error {
-  errCode: number;
-}
 
 export const useGetTimetable = (meetingId?: string) => {
   const navigate = useNavigate();
@@ -59,7 +55,7 @@ export const useGetTimetable = (meetingId?: string) => {
 
   useEffect(
     () => {
-      if (error && (error as ErrorType).errCode === 409) {
+      if (error && isAxiosError(error) && error.response?.status === 409) {
         navigate(`/q-card/${meetingId}`);
       }
     },

--- a/src/utils/apis/useGetTimetable.ts
+++ b/src/utils/apis/useGetTimetable.ts
@@ -34,8 +34,7 @@ const getTimetable = async (meetingId: string) => {
   } catch (err) {
     if (isAxiosError(err) && err.response) {
       const errCode = err.response.status;
-      const errMessage = err.response.data.message;
-      throw { errCode, errMessage };
+      throw { errCode };
     } else {
       throw new Error('알 수 없는 오류가 발생했습니다.');
     }
@@ -44,7 +43,6 @@ const getTimetable = async (meetingId: string) => {
 
 interface ErrorType extends Error {
   errCode: number;
-  errMessage: string;
 }
 
 export const useGetTimetable = (meetingId?: string) => {
@@ -62,7 +60,6 @@ export const useGetTimetable = (meetingId?: string) => {
   useEffect(
     () => {
       if (error && (error as ErrorType).errCode === 409) {
-        alert('이미 확정된 회의입니다.');
         navigate(`/q-card/${meetingId}`);
       }
     },


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 🌀 해당 이슈 번호

- close #252

## 🔹 어떤 것을 변경했나요?

- [x] 이미 확정된 회의(에러코드 409)라면 큐카드로 redirect

## 🔹 어떻게 구현했나요?
시간표 조회 api를 구현하는 `useGetTimetable.ts`에서 axiosError가 발생하면 에러 코드를 throw하여 이를 useQuery에서 받을수 있게 합니다. 에러 코드가 409라면 큐카드로 navigate합니다.

## 🔹 PR 포인트를 알려주세요!
처음에는 다음과 같이 코드를 작성했습니다.
```ts
export const useGetTimetable = (meetingId?: string) => {
  const navigate = useNavigate();
  if (meetingId === undefined) {
    navigate('/error');
    throw new Error('잘못된 회의 아이디입니다.');
  }
  const { data, isLoading, error } = useQuery({
    queryKey: ['getTimetable', meetingId],
    queryFn: () => getTimetable(meetingId),
    retry: 0,
  });

  useEffect(
    () => {
      if (error && (error as ErrorType).errCode === 409) {
        navigate(`/q-card/${meetingId}`);
      }
    },
    [error, navigate, meetingId],
  );

  return { data, isLoading, error };
};
```

그러나 이렇게하면 다음과 같은 오류가 발생합니다.
`useGetTimetable.ts:61 Warning: Cannot update a component (`BrowserRouter`) while rendering a different component (`SelectSchedule`).`

유저가 /:auth/select/:meetingId로 접속했을 때 SelectSchedule 컴포넌트를 렌더링하게 됩니다. 그런데 렌더링하는 도중에 api통신에서 409에러가 발생해버리고, 이 때 navigate를 시도하면서 BrowserRouter의 내부 상태를 변경하게 됩니다. 그래서 SelectSchedule을 렌더링하는 도중의 BrowserRouter를 업데이트 할 수 없다는 오류가 발생합니다.

이를 해결하기 위해 navigate하는 로직을 useEffect로 감쌌습니다. 이렇게 하면 SelectSchedule의 렌더링을 마친 후에 navigate를 실행할 수 있음을 보장하기 때문에 오류가 해결됩니다. 
```ts
  useEffect(
    () => {
      if (error && (error as ErrorType).errCode === 409) {
        navigate(`/q-card/${meetingId}`);
      }
    },
    [error, navigate, meetingId],
  );
```


## 🔹 스크린샷을 남겨주세요!
https://github.com/ASAP-as-soon-as-possible/ASAP_Client/assets/55528304/cd0d3351-1256-4c5f-9200-3599f73b50a6

바로 큐카드로 이동하는 모습!
