### PR TITLE
[Fix/#254] 큐카드 저장시 레이아웃 변경

### DIFF
--- a/src/pages/cueCard/CueCard.tsx
+++ b/src/pages/cueCard/CueCard.tsx
@@ -59,6 +59,8 @@ const CueCardWrapper = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: center;
+
+  width: 100%;
 `;
 
 const ButtonSection = styled.section`

--- a/src/pages/cueCard/CueCard.tsx
+++ b/src/pages/cueCard/CueCard.tsx
@@ -16,7 +16,7 @@ function CueCard() {
 
   const downLoadImage = () => {
     if (imageRef.current) {
-      html2canvas(imageRef.current).then((canvas) => {
+      html2canvas(imageRef.current, { backgroundColor: null }).then((canvas) => {
         const link = document.createElement('a');
         link.download = 'myimage.png';
         link.href = canvas.toDataURL('image/png');

--- a/src/pages/cueCard/components/CueCardTitle.tsx
+++ b/src/pages/cueCard/components/CueCardTitle.tsx
@@ -29,6 +29,6 @@ const TitleWrapper = styled.div`
   align-items: center;
   justify-content: center;
 
-  padding: 4.4rem 0 3.2rem 0;
+  padding: 4.4rem 0 1.8rem 0;
   width: 100%;
 `;

--- a/src/pages/cueCard/components/Qcard.tsx
+++ b/src/pages/cueCard/components/Qcard.tsx
@@ -15,7 +15,7 @@ const Qcard = forwardRef((_, ref: ForwardedRef<HTMLDivElement>) => {
   const navigate = useNavigate();
   const {isError, isloading, cueCardData } = GetQcardDataHooks(meetingId as unknown as string)
   if (isError) {
-    navigate(`/*`);
+    navigate(`/error`);
   } else if (!isloading && cueCardData) {
     const {
       data: {
@@ -132,8 +132,6 @@ const QcardWrapper = styled.article`
   display: flex;
   flex-direction: column;
   justify-content: center;
-  background-color: ${theme.colors.grey10};
-  padding: 1.5rem;
   width: 100%;
 `;
 

--- a/src/pages/cueCard/components/Qcard.tsx
+++ b/src/pages/cueCard/components/Qcard.tsx
@@ -1,13 +1,14 @@
 import { ForwardedRef, forwardRef } from 'react';
-import { OfflinePlaceIc, OnlinePlaceIc, TimeIc } from 'components/Icon/icon';
 
-import GetQcardDataHooks from '../hooks/getQCardData';
-import LoadingPage from 'pages/errorLoading/LoadingPage';
 import Text from 'components/atomComponents/Text';
+import { OfflinePlaceIc, OnlinePlaceIc, TimeIc } from 'components/Icon/icon';
+import LoadingPage from 'pages/errorLoading/LoadingPage';
+import { useParams } from 'react-router';
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components/macro';
 import { theme } from 'styles/theme';
-import { useNavigate } from 'react-router-dom';
-import { useParams } from 'react-router';
+
+import GetQcardDataHooks from '../hooks/getQCardData';
 
 const Qcard = forwardRef((_, ref: ForwardedRef<HTMLDivElement>) => {
   const { meetingId } = useParams();
@@ -131,7 +132,8 @@ const QcardWrapper = styled.article`
   display: flex;
   flex-direction: column;
   justify-content: center;
-  padding: 1rem 1.6rem 10rem 1rem;
+  background-color: ${theme.colors.grey10};
+  padding: 1.5rem;
   width: 100%;
 `;
 


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 🌀 해당 이슈 번호

- close #254 

## 🔹 어떤 것을 변경했나요?

- [x] 큐카드 레이아웃 변경

## 🔹 어떻게 구현했나요?
padding을 적절하게 맞추고 큐카드 컴포넌트의 background-color을 검정색으로 바꾸어 보기 좋은 모양새로 바꾸었습니다 ..ㅎㅎ

## 🔹 PR 포인트를 알려주세요!
정확히 어떤 모습으로 저장되면 될지 디자인쪽에 요청을 해야할듯합니다.

왜냐면 다음과 같이 배경을 아예 투명하게(png) 뽑는것도 가능하더라구요.
<img src="https://github.com/ASAP-as-soon-as-possible/ASAP_Client/assets/55528304/6866075f-0159-4756-b6f5-e8867a469db7" width="300"/>
(흰 배경이 없이 큐카드 모양대로 딱 잘려진 것임!!)
### -> 회의 결과 이 안으로 결정되어 수정했습니다~!!

근데 자세히보시면 밑에 점선이랑 양옆에 구멍뚫린 부분 보이시죠.. 이 부분을 투명하게 만들 수가 없다보니 어색한 부분도 있긴 합니다.

위 결과본이랑 아래 스크린샷을 남겨주세요! 에 두번째로 올린 결과물이랑 어떤게 더 나을지, 아니면 다른 방안이 있는지 회의 때 간단히 물어보면 좋을듯합니다!

## 🔹 스크린샷을 남겨주세요!
### 전후 비교

<img src="https://github.com/ASAP-as-soon-as-possible/ASAP_Client/assets/55528304/0e155301-307f-4782-892c-037556a5f411" width="300"/>
<img src="https://github.com/ASAP-as-soon-as-possible/ASAP_Client/assets/55528304/2dab91ee-aa65-401d-b5c1-c8cab5082cb2" width="300"/>