### PR TITLE
[ Hotfix/#272 ] 시간 배열의 0번째는 시간표에 우선순위 적용안되는 이슈 해결

### DIFF
--- a/src/pages/selectSchedule/components/selectPriority/PriorityColumn.tsx
+++ b/src/pages/selectSchedule/components/selectPriority/PriorityColumn.tsx
@@ -24,9 +24,9 @@ function PriorityColumn({ date, timeSlots }: ColumnStructure) {
         throw Error(`올바르지않은 priority ${priority}`);
     }
   };
-
-  const getPriorityColumnStyle = (priority: number, selectedEntryId?: number | null) => {
+  const getPriorityColumnStyle = (priority: number, selectedEntryId: number | null) => {
     const isSelectedSlot = selectedEntryId;
+
     const slotColor =
       priority === 3
         ? theme.colors.main1
@@ -61,7 +61,7 @@ function PriorityColumn({ date, timeSlots }: ColumnStructure) {
 
         const selectedEntryId = belongingEntry ? parseInt(belongingEntry[0]) : null;
         const slotId = `${date}/${timeSlot}`;
-        const priority = selectedEntryId ? selectedSlots[selectedEntryId].priority : 0;
+        const priority = selectedEntryId !== null ? selectedSlots[selectedEntryId].priority : 0;
 
         return (
           <Slot

--- a/src/pages/selectSchedule/components/selectPriority/PriorityDropdown.tsx
+++ b/src/pages/selectSchedule/components/selectPriority/PriorityDropdown.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import Text from 'components/atomComponents/Text';
 import { Circle1Ic, Circle2Ic, Circle3Ic, DropDownIc, DropUpIc } from 'components/Icon/icon';
@@ -123,6 +123,12 @@ function PriorityDropdown() {
     handleDropdown(idx);
   };
 
+  useEffect(
+    () => {
+      console.log(selectedSlots);
+    },
+    [selectedSlots],
+  );
   return (
     <PriorityDropdownWrapper>
       {Object.entries(selectedSlots).map(([key, _], idx) => {

--- a/src/pages/selectSchedule/components/selectPriority/PriorityDropdown.tsx
+++ b/src/pages/selectSchedule/components/selectPriority/PriorityDropdown.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 import Text from 'components/atomComponents/Text';
 import { Circle1Ic, Circle2Ic, Circle3Ic, DropDownIc, DropUpIc } from 'components/Icon/icon';
@@ -123,12 +123,6 @@ function PriorityDropdown() {
     handleDropdown(idx);
   };
 
-  useEffect(
-    () => {
-      console.log(selectedSlots);
-    },
-    [selectedSlots],
-  );
   return (
     <PriorityDropdownWrapper>
       {Object.entries(selectedSlots).map(([key, _], idx) => {


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 🌀 해당 이슈 번호

- close #272 

## 🔹 어떤 것을 변경했나요?

- [x] selectedEntryId가 0일 때 즉 시간 배열의 첫번째는 우선순위가 뷰에 적용안되던 이슈를 해결

## 🔹 어떻게 구현했나요?
```
        const priority = selectedEntryId ? selectedSlots[selectedEntryId].priority : 0;
```
위로직은 id가 0일 때, 즉 첫번째 원소일때도 falsy한값이므로 무조건 0으로 반환하기에 null임을 체크해주었습니다.

```
 const priority = selectedEntryId !== null ? selectedSlots[selectedEntryId].priority : 0;
```

## 🔹 PR 포인트를 알려주세요!

구현방식에 언급하였습니다!

## 🔹 스크린샷을 남겨주세요!
https://github.com/user-attachments/assets/71347490-3975-41b2-8afb-fcfbb9d67903


