### PR TITLE
[Feat/#285] 시간표 UI 변경 및 Slot 스타일링 로직의 의존성 분리

### DIFF
--- a/src/components/timetableComponents/Timetable.tsx
+++ b/src/components/timetableComponents/Timetable.tsx
@@ -6,20 +6,21 @@ import DateTitle from './parts/ColumnTitle';
 import SlotTitle from './parts/SlotTitle';
 import { ColumnStructure, DateType } from './types';
 
-interface TimetableProps {
+export interface TimetableProps {
   timeSlots: string[];
   availableDates: DateType[];
+  slotUnit: 'HALF' | 'HOUR';
   children: (props: ColumnStructure) => ReactNode;
   bottomItem?: ReactNode;
 }
 
-function Timetable({ timeSlots, availableDates, children, bottomItem }: TimetableProps) {
+function Timetable({ timeSlots, availableDates, slotUnit, children, bottomItem }: TimetableProps) {
   const emptyDates = Array.from({ length: 7 - availableDates.length }, (_, i) => `empty${i + 1}`);
 
   return (
     <>
       <TimetableWrapper>
-        <SlotTitle timeSlots={timeSlots} />
+        <SlotTitle timeSlots={timeSlots} slotUnit={slotUnit} />
         <TableWithDateWrapper>
           <DateTitle availableDates={availableDates} />
           <TableWrapper>
@@ -27,7 +28,7 @@ function Timetable({ timeSlots, availableDates, children, bottomItem }: Timetabl
               const dateKey = Object.values(date).join('/');
               return (
                 <ColumnWrapper key={dateKey}>
-                  {children({ date: dateKey, timeSlots })}
+                  {children({ date: dateKey, timeSlots, slotUnit })}
                 </ColumnWrapper>
               );
             })}

--- a/src/components/timetableComponents/Timetable.tsx
+++ b/src/components/timetableComponents/Timetable.tsx
@@ -28,7 +28,7 @@ function Timetable({ timeSlots, availableDates, slotUnit, children, bottomItem }
               const dateKey = Object.values(date).join('/');
               return (
                 <ColumnWrapper key={dateKey}>
-                  {children({ date: dateKey, timeSlots, slotUnit })}
+                  {children({ date: dateKey, timeSlots })}
                 </ColumnWrapper>
               );
             })}

--- a/src/components/timetableComponents/parts/Slot.tsx
+++ b/src/components/timetableComponents/parts/Slot.tsx
@@ -3,14 +3,13 @@ import { ReactNode } from 'react';
 import styled from 'styled-components';
 
 interface SlotProps {
-  slotId: string;
   customSlotStyle?: string;
   slotUnit: 'HALF' | 'HOUR';
   onClick?: () => void;
   children?: ReactNode;
 }
 
-function Slot({ slotId, customSlotStyle, slotUnit, onClick, children }: SlotProps) {
+function Slot({ customSlotStyle, slotUnit, onClick, children }: SlotProps) {
   const defaultSlotStyle = `
     width: 4.4rem;
     height: ${slotUnit === 'HALF' ? '2.2rem' : '1.2rem'};
@@ -18,16 +17,9 @@ function Slot({ slotId, customSlotStyle, slotUnit, onClick, children }: SlotProp
     justify-content: center;
   `;
 
-  const borderTopStyle = slotId.endsWith(':30')
-    ? slotUnit === 'HALF'
-      ? 'dashed'
-      : 'none'
-    : 'solid';
-
   return (
     <SlotWrapper
       $defaultSlotStyle={defaultSlotStyle}
-      $borderTopStyle={borderTopStyle}
       $customSlotStyle={customSlotStyle}
       onClick={onClick}
     >
@@ -40,11 +32,8 @@ export default Slot;
 
 const SlotWrapper = styled.div<{
   $defaultSlotStyle: string;
-  $borderTopStyle: string;
   $customSlotStyle?: string;
 }>`
-  border-top: 1px solid ${({ theme }) => theme.colors.grey7};
-  border-top-style: ${({ $borderTopStyle }) => $borderTopStyle};
   ${({ $defaultSlotStyle }) => $defaultSlotStyle};
   ${({ $customSlotStyle }) => $customSlotStyle};
 `;

--- a/src/components/timetableComponents/parts/Slot.tsx
+++ b/src/components/timetableComponents/parts/Slot.tsx
@@ -1,36 +1,50 @@
 import { ReactNode } from 'react';
+
 import styled from 'styled-components';
 
 interface SlotProps {
   slotId: string;
-  slotStyle?: string;
+  customSlotStyle?: string;
+  slotUnit: 'HALF' | 'HOUR';
   onClick?: () => void;
   children?: ReactNode;
 }
 
-function Slot({ slotId, slotStyle, onClick, children }: SlotProps) {
-  const borderStyle = slotId.endsWith(':30') ? 'dashed' : 'solid';
+function Slot({ slotId, customSlotStyle, slotUnit, onClick, children }: SlotProps) {
+  const defaultSlotStyle = `
+    width: 4.4rem;
+    height: ${slotUnit === 'HALF' ? '2.2rem' : '1.2rem'};
+    display: flex;
+    justify-content: center;
+  `;
+
+  const borderTopStyle = slotId.endsWith(':30')
+    ? slotUnit === 'HALF'
+      ? 'dashed'
+      : 'none'
+    : 'solid';
 
   return (
-    <DefaultSlot $borderStyle={borderStyle} $slotStyle={slotStyle} onClick={onClick}>
+    <SlotWrapper
+      $defaultSlotStyle={defaultSlotStyle}
+      $borderTopStyle={borderTopStyle}
+      $customSlotStyle={customSlotStyle}
+      onClick={onClick}
+    >
       {children}
-    </DefaultSlot>
+    </SlotWrapper>
   );
 }
 
 export default Slot;
 
-const DefaultSlot = styled.div<{
-  $borderStyle: string;
-  $slotStyle?: string;
+const SlotWrapper = styled.div<{
+  $defaultSlotStyle: string;
+  $borderTopStyle: string;
+  $customSlotStyle?: string;
 }>`
   border-top: 1px solid ${({ theme }) => theme.colors.grey7};
-  border-top-style: ${({ $borderStyle }) => $borderStyle};
-  ${({ $slotStyle }) => $slotStyle};
-
-  width: 4.4rem;
-  height: 2.2rem;
-
-  display: flex;
-  justify-content: center;
+  border-top-style: ${({ $borderTopStyle }) => $borderTopStyle};
+  ${({ $defaultSlotStyle }) => $defaultSlotStyle};
+  ${({ $customSlotStyle }) => $customSlotStyle};
 `;

--- a/src/components/timetableComponents/parts/Slot.tsx
+++ b/src/components/timetableComponents/parts/Slot.tsx
@@ -31,7 +31,7 @@ function Slot({ slotId, customSlotStyle, slotUnit, onClick, children }: SlotProp
       $customSlotStyle={customSlotStyle}
       onClick={onClick}
     >
-      {children}
+      <PriorityNumber>{children}</PriorityNumber>
     </SlotWrapper>
   );
 }
@@ -47,4 +47,13 @@ const SlotWrapper = styled.div<{
   border-top-style: ${({ $borderTopStyle }) => $borderTopStyle};
   ${({ $defaultSlotStyle }) => $defaultSlotStyle};
   ${({ $customSlotStyle }) => $customSlotStyle};
+`;
+
+const PriorityNumber = styled.div`
+  display: flex;
+  position: relative;
+  top: 6px;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
 `;

--- a/src/components/timetableComponents/parts/Slot.tsx
+++ b/src/components/timetableComponents/parts/Slot.tsx
@@ -4,15 +4,14 @@ import styled from 'styled-components';
 
 interface SlotProps {
   customSlotStyle?: string;
-  slotUnit: 'HALF' | 'HOUR';
   onClick?: () => void;
   children?: ReactNode;
 }
 
-function Slot({ customSlotStyle, slotUnit, onClick, children }: SlotProps) {
+function Slot({ customSlotStyle, onClick, children }: SlotProps) {
   const defaultSlotStyle = `
     width: 4.4rem;
-    height: ${slotUnit === 'HALF' ? '2.2rem' : '1.2rem'};
+    height: 2.2rem;
     display: flex;
     justify-content: center;
   `;

--- a/src/components/timetableComponents/parts/SlotTitle.tsx
+++ b/src/components/timetableComponents/parts/SlotTitle.tsx
@@ -18,10 +18,10 @@ function SlotTitle({ timeSlots, slotUnit }: SlotTitleProps) {
     <SlotTitleWrapper $slotUnit={slotUnit}>
       {parsedTimeSlots.map((slot) => (
         <Fragment key={slot}>
-          <Text font="body4" color={theme.colors.grey5} key={`${slot}-fill`}>
+          <Text font="body4" color={theme.colors.grey7} key={`${slot}-fill`}>
             {slot}
           </Text>
-          <Text font="body4" color={theme.colors.grey5} key={`${slot}-empty`}>
+          <Text font="body4" color={theme.colors.grey7} key={`${slot}-empty`}>
             {''}
           </Text>
         </Fragment>

--- a/src/components/timetableComponents/parts/SlotTitle.tsx
+++ b/src/components/timetableComponents/parts/SlotTitle.tsx
@@ -4,18 +4,18 @@ import Text from 'components/atomComponents/Text';
 import styled from 'styled-components';
 import { theme } from 'styles/theme';
 
-interface SlotTitleProps {
-  timeSlots: string[];
-}
+import { TimetableProps } from '../Timetable';
 
-function SlotTitle({ timeSlots }: SlotTitleProps) {
+type SlotTitleProps = Pick<TimetableProps, 'timeSlots' | 'slotUnit'>;
+
+function SlotTitle({ timeSlots, slotUnit }: SlotTitleProps) {
   const parsedTimeSlots = timeSlots
     .filter((slot) => !slot.endsWith('30'))
     .map((slot) => parseInt(slot.split(':')[0]));
   parsedTimeSlots.push(24);
 
   return (
-    <SlotTitleWrapper>
+    <SlotTitleWrapper $slotUnit={slotUnit}>
       {parsedTimeSlots.map((slot) => (
         <Fragment key={slot}>
           <Text font="body4" color={theme.colors.grey5} key={`${slot}-fill`}>
@@ -32,9 +32,9 @@ function SlotTitle({ timeSlots }: SlotTitleProps) {
 
 export default SlotTitle;
 
-const SlotTitleWrapper = styled.div`
+const SlotTitleWrapper = styled.div<{ $slotUnit: 'HALF' | 'HOUR' }>`
   display: flex;
   flex-direction: column;
-  gap: 1.4rem;
+  gap: ${({ $slotUnit }) => ($slotUnit === 'HALF' ? '1.4rem' : '0.4rem')};
   margin-top: 3.3rem;
 `;

--- a/src/components/timetableComponents/types.ts
+++ b/src/components/timetableComponents/types.ts
@@ -8,6 +8,7 @@ export interface TimetableStructure extends BaseStructure {
 
 export interface ColumnStructure extends BaseStructure {
   date: string;
+  slotUnit: 'HALF' | 'HOUR';
 }
 
 export interface DateType {

--- a/src/components/timetableComponents/types.ts
+++ b/src/components/timetableComponents/types.ts
@@ -8,7 +8,6 @@ export interface TimetableStructure extends BaseStructure {
 
 export interface ColumnStructure extends BaseStructure {
   date: string;
-  slotUnit: 'HALF' | 'HOUR';
 }
 
 export interface DateType {

--- a/src/pages/overallSchedule/components/OverallScheduleColumn.tsx
+++ b/src/pages/overallSchedule/components/OverallScheduleColumn.tsx
@@ -24,9 +24,13 @@ function OverallScheduleColumn({ date, timeSlots, availableSlotInfo }: OverallSc
     };
 
     const isClickedSlot = clickedSlot === slotId;
+    const borderStyle = slotId.endsWith(':30') ? 'none' : 'solid';
+    const borderTop = `1px ${borderStyle} ${theme.colors.grey7} `;
+
     return `
       background-color: ${isClickedSlot && colorLevel!==0 ? theme.colors.sub1 : COLOR[colorLevel]};
       cursor: ${colorLevel !== 0 ? 'pointer' : 'default'};
+      border-top: ${borderTop};
     `
   }
 
@@ -36,7 +40,7 @@ function OverallScheduleColumn({ date, timeSlots, availableSlotInfo }: OverallSc
         const { colorLevel = 0, userNames = [] } = availableSlotInfo.find((info) => info.time === timeSlot) ?? {};
         const slotId = `${date}/${timeSlot}`;
 
-        return <Slot key={slotId} slotId={slotId} slotStyle={getTimeSlotStyle(colorLevel, slotId)} onClick={()=>onClickSlot(slotId, userNames)}/>;
+        return <Slot key={slotId} slotUnit='HALF' customSlotStyle={getTimeSlotStyle(colorLevel, slotId)} onClick={()=>onClickSlot(slotId, userNames)}/>;
       })}
     </>
   );

--- a/src/pages/overallSchedule/components/OverallScheduleColumn.tsx
+++ b/src/pages/overallSchedule/components/OverallScheduleColumn.tsx
@@ -24,7 +24,7 @@ function OverallScheduleColumn({ date, timeSlots, availableSlotInfo }: OverallSc
     };
 
     /**
-     * 우선순위 입력 스타일링
+     * 종합일정 시간표 스타일링
      * 1. border-top: 선택된 시간이라면 none, 선택되지 않은 시간이라면 30분 단위는 none, 1시간 단위는 실선
      * 2. background-color: 선택된 시간이라면 colorLevel에 따른 색상
      */

--- a/src/pages/overallSchedule/components/OverallScheduleColumn.tsx
+++ b/src/pages/overallSchedule/components/OverallScheduleColumn.tsx
@@ -23,14 +23,20 @@ function OverallScheduleColumn({ date, timeSlots, availableSlotInfo }: OverallSc
       5: theme.colors.level5,
     };
 
+    /**
+     * 우선순위 입력 스타일링
+     * 1. border-top: 선택된 시간이라면 none, 선택되지 않은 시간이라면 30분 단위는 none, 1시간 단위는 실선
+     * 2. background-color: 선택된 시간이라면 colorLevel에 따른 색상
+     */
+    const borderTopStyle = slotId.endsWith(':30') ? 'none' : 'solid';
+    const borderTop = `1px ${borderTopStyle} ${theme.colors.grey7} `;
     const isClickedSlot = clickedSlot === slotId;
-    const borderStyle = slotId.endsWith(':30') ? 'none' : 'solid';
-    const borderTop = `1px ${borderStyle} ${theme.colors.grey7} `;
+    const backgroundColor = isClickedSlot && colorLevel !== 0 ? theme.colors.sub1 : COLOR[colorLevel];
 
     return `
-      background-color: ${isClickedSlot && colorLevel!==0 ? theme.colors.sub1 : COLOR[colorLevel]};
-      cursor: ${colorLevel !== 0 ? 'pointer' : 'default'};
       border-top: ${borderTop};
+      background-color: ${backgroundColor};
+      cursor: ${colorLevel !== 0 ? 'pointer' : 'default'};
     `
   }
 

--- a/src/pages/overallSchedule/components/OverallScheduleColumn.tsx
+++ b/src/pages/overallSchedule/components/OverallScheduleColumn.tsx
@@ -46,7 +46,7 @@ function OverallScheduleColumn({ date, timeSlots, availableSlotInfo }: OverallSc
         const { colorLevel = 0, userNames = [] } = availableSlotInfo.find((info) => info.time === timeSlot) ?? {};
         const slotId = `${date}/${timeSlot}`;
 
-        return <Slot key={slotId} slotUnit='HALF' customSlotStyle={getTimeSlotStyle(colorLevel, slotId)} onClick={()=>onClickSlot(slotId, userNames)}/>;
+        return <Slot key={slotId} customSlotStyle={getTimeSlotStyle(colorLevel, slotId)} onClick={()=>onClickSlot(slotId, userNames)}/>;
       })}
     </>
   );

--- a/src/pages/overallSchedule/components/OverallScheduleTable.tsx
+++ b/src/pages/overallSchedule/components/OverallScheduleTable.tsx
@@ -46,11 +46,17 @@ function OverallScheduleTable({
         setClickedUserNames,
       }}
     >
-      <Timetable timeSlots={timeSlots} availableDates={availableDates} bottomItem={<UserNames />}>
+      <Timetable
+        timeSlots={timeSlots}
+        availableDates={availableDates}
+        slotUnit="HALF"
+        bottomItem={<UserNames />}
+      >
         {({ date, timeSlots }: ColumnStructure) => (
           <OverallScheduleColumn
             date={date}
             timeSlots={timeSlots}
+            slotUnit="HALF"
             availableSlotInfo={getAvailableTimesPerDate(
               dataOverallSchedule.availableDateTimes,
               date,

--- a/src/pages/overallSchedule/components/OverallScheduleTable.tsx
+++ b/src/pages/overallSchedule/components/OverallScheduleTable.tsx
@@ -56,7 +56,6 @@ function OverallScheduleTable({
           <OverallScheduleColumn
             date={date}
             timeSlots={timeSlots}
-            slotUnit="HALF"
             availableSlotInfo={getAvailableTimesPerDate(
               dataOverallSchedule.availableDateTimes,
               date,

--- a/src/pages/selectSchedule/components/SelectScheduleTable.tsx
+++ b/src/pages/selectSchedule/components/SelectScheduleTable.tsx
@@ -18,12 +18,14 @@ function SelectScheduleTable({ timeSlots, availableDates }: TimetableStructure) 
 
   const { scheduleStep } = useScheduleStepContext();
 
+  const slotUnit = scheduleStep === 'selectTimeSlot' ? 'HALF' : 'HOUR';
+
   const stepColumns: StepSlotsType = {
     selectTimeSlot: ({ date, timeSlots }: ColumnStructure) => (
-      <SelectionColumn date={date} timeSlots={timeSlots} />
+      <SelectionColumn date={date} timeSlots={timeSlots} slotUnit={slotUnit} />
     ),
     selectPriority: ({ date, timeSlots }: ColumnStructure) => (
-      <PriorityColumn date={date} timeSlots={timeSlots} />
+      <PriorityColumn date={date} timeSlots={timeSlots} slotUnit={slotUnit} />
     ),
   };
   const stepColumn = stepColumns[scheduleStep];
@@ -48,7 +50,12 @@ function SelectScheduleTable({ timeSlots, availableDates }: TimetableStructure) 
         setSelectedSlots,
       }}
     >
-      <Timetable timeSlots={timeSlots} availableDates={availableDates} bottomItem={bottomItem}>
+      <Timetable
+        timeSlots={timeSlots}
+        availableDates={availableDates}
+        slotUnit={slotUnit}
+        bottomItem={bottomItem}
+      >
         {stepColumn}
       </Timetable>
     </SelectContext.Provider>

--- a/src/pages/selectSchedule/components/SelectScheduleTable.tsx
+++ b/src/pages/selectSchedule/components/SelectScheduleTable.tsx
@@ -22,10 +22,10 @@ function SelectScheduleTable({ timeSlots, availableDates }: TimetableStructure) 
 
   const stepColumns: StepSlotsType = {
     selectTimeSlot: ({ date, timeSlots }: ColumnStructure) => (
-      <SelectionColumn date={date} timeSlots={timeSlots} slotUnit={slotUnit} />
+      <SelectionColumn date={date} timeSlots={timeSlots} />
     ),
     selectPriority: ({ date, timeSlots }: ColumnStructure) => (
-      <PriorityColumn date={date} timeSlots={timeSlots} slotUnit={slotUnit} />
+      <PriorityColumn date={date} timeSlots={timeSlots} />
     ),
   };
   const stepColumn = stepColumns[scheduleStep];

--- a/src/pages/selectSchedule/components/selectPriority/PriorityColumn.tsx
+++ b/src/pages/selectSchedule/components/selectPriority/PriorityColumn.tsx
@@ -40,13 +40,18 @@ function PriorityColumn({ date, timeSlots, slotUnit }: ColumnStructure) {
             ? theme.colors.main3
             : theme.colors.grey6;
 
-    const borderStyle = slotId.endsWith(':30') ? 'none' : 'solid';
+    /**
+     * 우선순위 입력 스타일링
+     * 1. border-top: 선택된 시간이라면 none, 선택되지 않은 시간이라면 30분 단위는 none, 1시간 단위는 실선
+     * 2. background-color: 선택된 시간이라면 우선순위에 따른 slotColor
+     */
+    const borderTopStyle = slotId.endsWith(':30') ? 'none' : 'solid';
+    const borderTop = isSelectedSlot ? 'none' : `1px ${borderTopStyle} ${theme.colors.grey7}`;
     const backgroundColor = isSelectedSlot ? slotColor : 'transparent';
-    const borderTop = isSelectedSlot ? 'none' : `1px ${borderStyle} ${theme.colors.grey7}`;
 
     return `
-        background-color : ${backgroundColor};
         border-top: ${borderTop};
+        background-color : ${backgroundColor};
     `;
   };
 

--- a/src/pages/selectSchedule/components/selectPriority/PriorityColumn.tsx
+++ b/src/pages/selectSchedule/components/selectPriority/PriorityColumn.tsx
@@ -5,7 +5,7 @@ import { theme } from 'styles/theme';
 
 import Slot from '../../../../components/timetableComponents/parts/Slot';
 
-function PriorityColumn({ date, timeSlots }: ColumnStructure) {
+function PriorityColumn({ date, timeSlots, slotUnit }: ColumnStructure) {
   const { selectedSlots } = useSelectContext();
 
   const selectedSlotsPerDate = Object.entries(selectedSlots).filter(
@@ -67,7 +67,8 @@ function PriorityColumn({ date, timeSlots }: ColumnStructure) {
           <Slot
             key={slotId}
             slotId={slotId}
-            slotStyle={getPriorityColumnStyle(priority, selectedEntryId)}
+            slotUnit={slotUnit}
+            customSlotStyle={getPriorityColumnStyle(priority, selectedEntryId)}
           >
             <Text font="body1" color={theme.colors.white}>
               {isFirstSlot && priority !== 0 ? changePriorityValue(priority) : ''}

--- a/src/pages/selectSchedule/components/selectPriority/PriorityColumn.tsx
+++ b/src/pages/selectSchedule/components/selectPriority/PriorityColumn.tsx
@@ -5,7 +5,7 @@ import { theme } from 'styles/theme';
 
 import Slot from '../../../../components/timetableComponents/parts/Slot';
 
-function PriorityColumn({ date, timeSlots, slotUnit }: ColumnStructure) {
+function PriorityColumn({ date, timeSlots }: ColumnStructure) {
   const { selectedSlots } = useSelectContext();
 
   const selectedSlotsPerDate = Object.entries(selectedSlots).filter(
@@ -48,10 +48,12 @@ function PriorityColumn({ date, timeSlots, slotUnit }: ColumnStructure) {
     const borderTopStyle = slotId.endsWith(':30') ? 'none' : 'solid';
     const borderTop = isSelectedSlot ? 'none' : `1px ${borderTopStyle} ${theme.colors.grey7}`;
     const backgroundColor = isSelectedSlot ? slotColor : 'transparent';
+    const height = '1.2rem';
 
     return `
         border-top: ${borderTop};
-        background-color : ${backgroundColor};
+        background-color: ${backgroundColor};
+        height: ${height};
     `;
   };
 
@@ -76,7 +78,6 @@ function PriorityColumn({ date, timeSlots, slotUnit }: ColumnStructure) {
         return (
           <Slot
             key={slotId}
-            slotUnit={slotUnit}
             customSlotStyle={getPriorityColumnStyle(slotId, priority, selectedEntryId)}
           >
             <Text font="body1" color={theme.colors.white}>

--- a/src/pages/selectSchedule/components/selectPriority/PriorityColumn.tsx
+++ b/src/pages/selectSchedule/components/selectPriority/PriorityColumn.tsx
@@ -24,8 +24,12 @@ function PriorityColumn({ date, timeSlots, slotUnit }: ColumnStructure) {
         throw Error(`올바르지않은 priority ${priority}`);
     }
   };
-  const getPriorityColumnStyle = (priority: number, selectedEntryId: number | null) => {
-    const isSelectedSlot = selectedEntryId;
+  const getPriorityColumnStyle = (
+    slotId: string,
+    priority: number,
+    selectedEntryId: number | null,
+  ) => {
+    const isSelectedSlot = selectedEntryId !== null;
 
     const slotColor =
       priority === 3
@@ -36,13 +40,13 @@ function PriorityColumn({ date, timeSlots, slotUnit }: ColumnStructure) {
             ? theme.colors.main3
             : theme.colors.grey6;
 
+    const borderStyle = slotId.endsWith(':30') ? 'none' : 'solid';
+    const backgroundColor = isSelectedSlot ? slotColor : 'transparent';
+    const borderTop = isSelectedSlot ? 'none' : `1px ${borderStyle} ${theme.colors.grey7}`;
+
     return `
-        ${
-          isSelectedSlot !== null
-            ? `background-color:${slotColor}`
-            : `background-color: transparent`
-        };
-        ${isSelectedSlot !== null && 'border-top-style: none'};
+        background-color : ${backgroundColor};
+        border-top: ${borderTop};
     `;
   };
 
@@ -67,9 +71,8 @@ function PriorityColumn({ date, timeSlots, slotUnit }: ColumnStructure) {
         return (
           <Slot
             key={slotId}
-            slotId={slotId}
             slotUnit={slotUnit}
-            customSlotStyle={getPriorityColumnStyle(priority, selectedEntryId)}
+            customSlotStyle={getPriorityColumnStyle(slotId, priority, selectedEntryId)}
           >
             <Text font="body1" color={theme.colors.white}>
               {isFirstSlot && priority !== 0 ? changePriorityValue(priority) : ''}

--- a/src/pages/selectSchedule/components/selectPriority/PriorityColumn.tsx
+++ b/src/pages/selectSchedule/components/selectPriority/PriorityColumn.tsx
@@ -41,7 +41,8 @@ function PriorityColumn({ date, timeSlots, slotUnit }: ColumnStructure) {
           isSelectedSlot !== null
             ? `background-color:${slotColor}`
             : `background-color: transparent`
-        }
+        };
+        ${isSelectedSlot !== null && 'border-top-style: none'};
     `;
   };
 

--- a/src/pages/selectSchedule/components/selectTimeSlot/SelectionColumn.tsx
+++ b/src/pages/selectSchedule/components/selectTimeSlot/SelectionColumn.tsx
@@ -17,6 +17,12 @@ function SelectionColumn({ date, timeSlots, slotUnit }: ColumnStructure) {
     const isStartSlot = slotId === startSlot;
     const isSelectedSlot = selectedEntryId !== undefined;
 
+    /**
+     * 가능시간 입력 시간표 스타일링
+     * 1. border-top: 30분 단위는 dashed, 1시간 단위는 solid
+     * 2. border: 탭투탭 시 startSlot에 dashed
+     * 3. background-color: 탭투탭으로 선택된 시간이면 main1, 그 외는 transparent;
+     */
     const borderStyle = slotId.endsWith(':30') ? 'dashed' : 'solid';
     const border = isStartSlot && `1px dashed ${theme.colors.main5}`;
     const borderTop = `1px ${borderStyle} ${theme.colors.grey7}`;
@@ -25,7 +31,7 @@ function SelectionColumn({ date, timeSlots, slotUnit }: ColumnStructure) {
     return `
       cursor:pointer;
       border-top: ${borderTop};
-      border: ${border};
+      ${isStartSlot && `border: ${border}`};
       background-color: ${backgroundColor};
     `;
   };

--- a/src/pages/selectSchedule/components/selectTimeSlot/SelectionColumn.tsx
+++ b/src/pages/selectSchedule/components/selectTimeSlot/SelectionColumn.tsx
@@ -17,12 +17,16 @@ function SelectionColumn({ date, timeSlots, slotUnit }: ColumnStructure) {
     const isStartSlot = slotId === startSlot;
     const isSelectedSlot = selectedEntryId !== undefined;
 
+    const borderStyle = slotId.endsWith(':30') ? 'dashed' : 'solid';
+    const border = isStartSlot && `1px dashed ${theme.colors.main5}`;
+    const borderTop = `1px ${borderStyle} ${theme.colors.grey7}`;
+    const backgroundColor = isSelectedSlot ? theme.colors.main1 : 'transparent';
+
     return `
       cursor:pointer;
-      ${isStartSlot && `border: 1px dashed ${theme.colors.main5}`};
-      ${
-        isSelectedSlot ? `background-color: ${theme.colors.main1}` : `background-color: transparent`
-      };
+      border-top: ${borderTop};
+      border: ${border};
+      background-color: ${backgroundColor};
     `;
   };
 
@@ -38,7 +42,6 @@ function SelectionColumn({ date, timeSlots, slotUnit }: ColumnStructure) {
         return (
           <Slot
             key={slotId}
-            slotId={slotId}
             slotUnit={slotUnit}
             customSlotStyle={getTimeSlotStyle(slotId, selectedEntryId)}
             onClick={() => onClickSlot(slotId, selectedEntryId)}

--- a/src/pages/selectSchedule/components/selectTimeSlot/SelectionColumn.tsx
+++ b/src/pages/selectSchedule/components/selectTimeSlot/SelectionColumn.tsx
@@ -16,23 +16,30 @@ function SelectionColumn({ date, timeSlots }: ColumnStructure) {
   const getTimeSlotStyle = (slotId: string, selectedEntryId?: number) => {
     const isStartSlot = slotId === startSlot;
     const isSelectedSlot = selectedEntryId !== undefined;
+    const isFirstSlot =
+      selectedEntryId !== undefined &&
+      selectedSlots[selectedEntryId].startSlot === slotId.split('/')[3];
 
     /**
      * 가능시간 입력 시간표 스타일링
      * 1. border-top: 30분 단위는 dashed, 1시간 단위는 solid
      * 2. border: 탭투탭 시 startSlot에 dashed
-     * 3. background-color: 탭투탭으로 선택된 시간이면 main1, 그 외는 transparent;
+     * 3. background-color: 선택된 시간이면서 맨 첫번째 Slot이라면 그라디언트, 그 외는 main1, 선택된 시간이 아니면 transparent;
      */
     const borderStyle = slotId.endsWith(':30') ? 'dashed' : 'solid';
     const border = isStartSlot && `1px dashed ${theme.colors.main5}`;
     const borderTop = `1px ${borderStyle} ${theme.colors.grey7}`;
-    const backgroundColor = isSelectedSlot ? theme.colors.main1 : 'transparent';
+    const background = isSelectedSlot
+      ? isFirstSlot
+        ? 'linear-gradient(180deg, #496AFF 0%, #3253FF 75%)'
+        : theme.colors.main1
+      : 'transparent';
 
     return `
       cursor:pointer;
       border-top: ${borderTop};
       ${isStartSlot && `border: ${border}`};
-      background-color: ${backgroundColor};
+      background: ${background};
     `;
   };
 

--- a/src/pages/selectSchedule/components/selectTimeSlot/SelectionColumn.tsx
+++ b/src/pages/selectSchedule/components/selectTimeSlot/SelectionColumn.tsx
@@ -5,7 +5,7 @@ import { theme } from 'styles/theme';
 import useSlotSeletion from './hooks/useSlotSelection';
 import Slot from '../../../../components/timetableComponents/parts/Slot';
 
-function SelectionColumn({ date, timeSlots }: ColumnStructure) {
+function SelectionColumn({ date, timeSlots, slotUnit }: ColumnStructure) {
   const { selectedSlots } = useSelectContext();
   const selectedSlotsPerDate = Object.entries(selectedSlots).filter(
     ([, slot]) => slot.date === date,
@@ -39,7 +39,8 @@ function SelectionColumn({ date, timeSlots }: ColumnStructure) {
           <Slot
             key={slotId}
             slotId={slotId}
-            slotStyle={getTimeSlotStyle(slotId, selectedEntryId)}
+            slotUnit={slotUnit}
+            customSlotStyle={getTimeSlotStyle(slotId, selectedEntryId)}
             onClick={() => onClickSlot(slotId, selectedEntryId)}
           />
         );

--- a/src/pages/selectSchedule/components/selectTimeSlot/SelectionColumn.tsx
+++ b/src/pages/selectSchedule/components/selectTimeSlot/SelectionColumn.tsx
@@ -5,7 +5,7 @@ import { theme } from 'styles/theme';
 import useSlotSeletion from './hooks/useSlotSelection';
 import Slot from '../../../../components/timetableComponents/parts/Slot';
 
-function SelectionColumn({ date, timeSlots, slotUnit }: ColumnStructure) {
+function SelectionColumn({ date, timeSlots }: ColumnStructure) {
   const { selectedSlots } = useSelectContext();
   const selectedSlotsPerDate = Object.entries(selectedSlots).filter(
     ([, slot]) => slot.date === date,
@@ -48,7 +48,6 @@ function SelectionColumn({ date, timeSlots, slotUnit }: ColumnStructure) {
         return (
           <Slot
             key={slotId}
-            slotUnit={slotUnit}
             customSlotStyle={getTimeSlotStyle(slotId, selectedEntryId)}
             onClick={() => onClickSlot(slotId, selectedEntryId)}
           />

--- a/src/pages/selectSchedule/utils.ts
+++ b/src/pages/selectSchedule/utils.ts
@@ -25,6 +25,7 @@ export const TITLES: TitlesType = {
   },
   selectPriority: {
     main: '우선순위를 입력해주세요',
+    sub: '선호하는 회의시간대 최대 3순위까지 입력해주세요',
   },
 } as const;
 


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 🌀 해당 이슈 번호

- close #285

## 🔹 어떤 것을 변경했나요?

- [x] 우선순위 입력 시간표 30분 단위 점선 삭제
- [x] 우선순위 입력 시간표에서 한 slot의 height를 줄임
- [x] 종합일정 시간표에서 30분 단위 점선 삭제
- [x] 위의 작업을 위해, Slot에 대한 스타일링의 의존성을 각 컴포넌트로 이동
- [x] 우선순위 페이지에 subtitle 추가 (선호하는 회의시간대 최대 3순위까지 입력해주세요)
- [x] 탭투탭 첫 블럭에 그라데이션

## 🔹 어떻게 구현했나요?
### 30분 단위의 유무에 대한 스타일링 처리를 위해 `slotUnit` prop 추가

<img src='https://github.com/user-attachments/assets/fb5bdad4-6151-4f33-8d9f-b8c36e759165' width="300"/>
<img src='https://github.com/user-attachments/assets/28db13f9-71a5-49ec-973a-953f04c41ab6' width="300"/>

좌측이 30분 단위가 있을 때, 우측이 30분 단위가 없을 때인데요.
좌 -> 우로 갈때 달라지는 점은 3가지 입니다.
1. SlotTitle(좌측에 세로로 시간을 나타내는 6,7,8,9,...24)의 간격이 줄어듦
2. 한 Slot(30분)의 높이가 줄어듦
3. 30분 단위에 대한 점선이 없어짐

1번은 SlotTitle 컴포넌트에 적용되어야 하는 변화이고,
2,3번은 Slot 컴포넌트에 적용되어야 하는 변화입니다.
SlotTitle 컴포넌트와 Slot 컴포넌트 모두 세가지의 시간표 컴포넌트에서 공통 컴포넌트로 사용되고 있는 것이기 때문에
이 변화를 모두 prop을 추가하여 적용하려면 prop에 대한 의존성이 증가하고 코드량이 늘어나기 때문에
이 문제를 최소화하기 위해, SlotTitle에만 prop을 새로 만들어 내려주기로 했습니다.

따라서 SlotTitle에 slotUnit prop('HALF' | 'HOUR')을 내려주어, 이에 따라 간격을 조절합니다.
```js
// SlotTitle.tsx
const SlotTitleWrapper = styled.div<{ $slotUnit: 'HALF' | 'HOUR' }>`
  display: flex;
  flex-direction: column;
  gap: ${({ $slotUnit }) => ($slotUnit === 'HALF' ? '1.4rem' : '0.4rem')};
  margin-top: 3.3rem;
`;
```

### Slot 스타일링 로직의 의존성 분리
ASAP 2.0에서, 세가지 시간표의 Slot 컴포넌트와 관련된 UI 차이를 정리해보면 다음과 같습니다.

구분 | 가능시간 입력 시간표 | 우선순위 입력 시간표 | 종합일정 시간표
-- | -- | -- | --
30분 단위 border | 점선 | 선 없음 | 선 없음
1시간 단위 borer | 실선 | 실선 | 실선
30분 단위 한 칸의 height | 2.2rem | 1.2rem | 2.2rem
이미지 | <img src="https://github.com/user-attachments/assets/2c092e60-fd19-4c2c-baa9-6b9ec91a4834" width="200"/> | <img src="https://github.com/user-attachments/assets/46e861b0-dae8-4f8d-b0aa-bf7f28f9ff43" width="200"/> | <img src="https://github.com/user-attachments/assets/f6b49536-e0e6-44e2-9eee-827342ffe4ee" width="200"/>

~굉장합니다...~ 

시간표 공통 컴포넌트를 사용하는거 치고 너무 베리에이션이 많다보니 개발 복잡성이 너무 증가하는 것 같아서,
사실 디자인 쪽에 통일을 요청할까도 생각했지만...
Slot에 대한 스타일링을 각 Column 컴포넌트(SelectionColumn, PriorityColumn, OverallScheduleColumn)에 위임한다면 충분히 가능할 것 같아서 그렇게 진행했습니다.

#### SelectionColumn
```js
/**
 * 가능시간 입력 시간표 스타일링
 * 1. border-top: 30분 단위는 dashed, 1시간 단위는 solid
 * 2. border: 탭투탭 시 startSlot에 dashed
 * 3. background-color: 선택된 시간이면서 맨 첫번째 Slot이라면 그라디언트, 그 외는 main1, 선택된 시간이 아니면 transparent;
 */
const borderStyle = slotId.endsWith(':30') ? 'dashed' : 'solid';
const border = isStartSlot && `1px dashed ${theme.colors.main5}`;
const borderTop = `1px ${borderStyle} ${theme.colors.grey7}`;
const background = isSelectedSlot
  ? isFirstSlot
    ? 'linear-gradient(180deg, #496AFF 0%, #3253FF 75%)'
    : theme.colors.main1
  : 'transparent';

return `
  cursor:pointer;
  border-top: ${borderTop};
  ${isStartSlot && `border: ${border}`};
  background: ${background};
`;
```
위 내용을 Slot 컴포넌트에 customSlotStyle prop으로 전달합니다.

#### PriorityColumn
```js
/**
 * 우선순위 입력 스타일링
 * 1. border-top: 선택된 시간이라면 none, 선택되지 않은 시간이라면 30분 단위는 none, 1시간 단위는 실선
 * 2. background-color: 선택된 시간이라면 우선순위에 따른 slotColor
 */
const borderTopStyle = slotId.endsWith(':30') ? 'none' : 'solid';
const borderTop = isSelectedSlot ? 'none' : `1px ${borderTopStyle} ${theme.colors.grey7}`;
const backgroundColor = isSelectedSlot ? slotColor : 'transparent';
const height = '1.2rem';

return `
    border-top: ${borderTop};
    background-color: ${backgroundColor};
    height: ${height};
`;
```
위 내용을 Slot 컴포넌트에 customSlotStyle prop으로 전달합니다.

### OverallScheduleColumn
```js
/**
 * 종합일정 시간표 스타일링
 * 1. border-top: 선택된 시간이라면 none, 선택되지 않은 시간이라면 30분 단위는 none, 1시간 단위는 실선
 * 2. background-color: 선택된 시간이라면 colorLevel에 따른 색상
 */
const borderTopStyle = slotId.endsWith(':30') ? 'none' : 'solid';
const borderTop = `1px ${borderTopStyle} ${theme.colors.grey7} `;
const isClickedSlot = clickedSlot === slotId;
const backgroundColor = isClickedSlot && colorLevel !== 0 ? theme.colors.sub1 : COLOR[colorLevel];

return `
  border-top: ${borderTop};
  background-color: ${backgroundColor};
  cursor: ${colorLevel !== 0 ? 'pointer' : 'default'};
    `
```
위 내용을 Slot 컴포넌트에 customSlotStyle prop으로 전달합니다.


말로 전달하기가 어려운 내용이라서
이해가 안되신다면 알려주세요 디코로 설명드리겠습니다!


## 🔹 스크린샷을 남겨주세요!
### 가능시간입력
![image](https://github.com/user-attachments/assets/5ecfd727-eef3-4516-b369-5ccc82ccef5c)

### 우선순위입력
![image](https://github.com/user-attachments/assets/8243671f-0bd2-4a7a-b7fd-5832a27a77ba)

### 종합일정시간표
![스크린샷 2024-07-27 오후 10 13 51](https://github.com/user-attachments/assets/0454cf1f-52b4-4ad7-8781-0fd65f4a2019)

