### PR TITLE
[Fix/#287] 참여자 가능시간 입력시 새로고침하면 참여자 이름이 날아가는 문제 수정

### DIFF
--- a/src/atoms/atom.ts
+++ b/src/atoms/atom.ts
@@ -1,7 +1,9 @@
-import { DateStates, ScheduleStates, TimeStates } from 'pages/legacy/selectSchedule/types/Schedule';
-
 import { PreferTime } from 'components/legacy/scheduleComponents/types/AvailableScheduleType';
+import { DateStates, ScheduleStates } from 'pages/legacy/selectSchedule/types/Schedule';
 import { atom } from 'recoil';
+import { recoilPersist } from 'recoil-persist';
+
+const { persistAtom } = recoilPersist();
 
 export const methodStateAtom = atom<boolean>({
   key: 'methodStateAtom',
@@ -44,4 +46,5 @@ export const clickedTimeSlotAtom = atom<string>({
 export const userNameAtom = atom<string>({
   key: 'userNameAtom',
   default: '',
+  effects_UNSTABLE: [persistAtom],
 });

--- a/src/components/timetableComponents/Timetable.tsx
+++ b/src/components/timetableComponents/Timetable.tsx
@@ -6,20 +6,21 @@ import DateTitle from './parts/ColumnTitle';
 import SlotTitle from './parts/SlotTitle';
 import { ColumnStructure, DateType } from './types';
 
-interface TimetableProps {
+export interface TimetableProps {
   timeSlots: string[];
   availableDates: DateType[];
+  slotUnit: 'HALF' | 'HOUR';
   children: (props: ColumnStructure) => ReactNode;
   bottomItem?: ReactNode;
 }
 
-function Timetable({ timeSlots, availableDates, children, bottomItem }: TimetableProps) {
+function Timetable({ timeSlots, availableDates, slotUnit, children, bottomItem }: TimetableProps) {
   const emptyDates = Array.from({ length: 7 - availableDates.length }, (_, i) => `empty${i + 1}`);
 
   return (
     <>
       <TimetableWrapper>
-        <SlotTitle timeSlots={timeSlots} />
+        <SlotTitle timeSlots={timeSlots} slotUnit={slotUnit} />
         <TableWithDateWrapper>
           <DateTitle availableDates={availableDates} />
           <TableWrapper>
@@ -27,7 +28,7 @@ function Timetable({ timeSlots, availableDates, children, bottomItem }: Timetabl
               const dateKey = Object.values(date).join('/');
               return (
                 <ColumnWrapper key={dateKey}>
-                  {children({ date: dateKey, timeSlots })}
+                  {children({ date: dateKey, timeSlots, slotUnit })}
                 </ColumnWrapper>
               );
             })}

--- a/src/components/timetableComponents/Timetable.tsx
+++ b/src/components/timetableComponents/Timetable.tsx
@@ -28,7 +28,7 @@ function Timetable({ timeSlots, availableDates, slotUnit, children, bottomItem }
               const dateKey = Object.values(date).join('/');
               return (
                 <ColumnWrapper key={dateKey}>
-                  {children({ date: dateKey, timeSlots, slotUnit })}
+                  {children({ date: dateKey, timeSlots })}
                 </ColumnWrapper>
               );
             })}

--- a/src/components/timetableComponents/parts/Slot.tsx
+++ b/src/components/timetableComponents/parts/Slot.tsx
@@ -3,14 +3,13 @@ import { ReactNode } from 'react';
 import styled from 'styled-components';
 
 interface SlotProps {
-  slotId: string;
   customSlotStyle?: string;
   slotUnit: 'HALF' | 'HOUR';
   onClick?: () => void;
   children?: ReactNode;
 }
 
-function Slot({ slotId, customSlotStyle, slotUnit, onClick, children }: SlotProps) {
+function Slot({ customSlotStyle, slotUnit, onClick, children }: SlotProps) {
   const defaultSlotStyle = `
     width: 4.4rem;
     height: ${slotUnit === 'HALF' ? '2.2rem' : '1.2rem'};
@@ -18,16 +17,9 @@ function Slot({ slotId, customSlotStyle, slotUnit, onClick, children }: SlotProp
     justify-content: center;
   `;
 
-  const borderTopStyle = slotId.endsWith(':30')
-    ? slotUnit === 'HALF'
-      ? 'dashed'
-      : 'none'
-    : 'solid';
-
   return (
     <SlotWrapper
       $defaultSlotStyle={defaultSlotStyle}
-      $borderTopStyle={borderTopStyle}
       $customSlotStyle={customSlotStyle}
       onClick={onClick}
     >
@@ -40,11 +32,8 @@ export default Slot;
 
 const SlotWrapper = styled.div<{
   $defaultSlotStyle: string;
-  $borderTopStyle: string;
   $customSlotStyle?: string;
 }>`
-  border-top: 1px solid ${({ theme }) => theme.colors.grey7};
-  border-top-style: ${({ $borderTopStyle }) => $borderTopStyle};
   ${({ $defaultSlotStyle }) => $defaultSlotStyle};
   ${({ $customSlotStyle }) => $customSlotStyle};
 `;

--- a/src/components/timetableComponents/parts/Slot.tsx
+++ b/src/components/timetableComponents/parts/Slot.tsx
@@ -1,36 +1,50 @@
 import { ReactNode } from 'react';
+
 import styled from 'styled-components';
 
 interface SlotProps {
   slotId: string;
-  slotStyle?: string;
+  customSlotStyle?: string;
+  slotUnit: 'HALF' | 'HOUR';
   onClick?: () => void;
   children?: ReactNode;
 }
 
-function Slot({ slotId, slotStyle, onClick, children }: SlotProps) {
-  const borderStyle = slotId.endsWith(':30') ? 'dashed' : 'solid';
+function Slot({ slotId, customSlotStyle, slotUnit, onClick, children }: SlotProps) {
+  const defaultSlotStyle = `
+    width: 4.4rem;
+    height: ${slotUnit === 'HALF' ? '2.2rem' : '1.2rem'};
+    display: flex;
+    justify-content: center;
+  `;
+
+  const borderTopStyle = slotId.endsWith(':30')
+    ? slotUnit === 'HALF'
+      ? 'dashed'
+      : 'none'
+    : 'solid';
 
   return (
-    <DefaultSlot $borderStyle={borderStyle} $slotStyle={slotStyle} onClick={onClick}>
+    <SlotWrapper
+      $defaultSlotStyle={defaultSlotStyle}
+      $borderTopStyle={borderTopStyle}
+      $customSlotStyle={customSlotStyle}
+      onClick={onClick}
+    >
       {children}
-    </DefaultSlot>
+    </SlotWrapper>
   );
 }
 
 export default Slot;
 
-const DefaultSlot = styled.div<{
-  $borderStyle: string;
-  $slotStyle?: string;
+const SlotWrapper = styled.div<{
+  $defaultSlotStyle: string;
+  $borderTopStyle: string;
+  $customSlotStyle?: string;
 }>`
   border-top: 1px solid ${({ theme }) => theme.colors.grey7};
-  border-top-style: ${({ $borderStyle }) => $borderStyle};
-  ${({ $slotStyle }) => $slotStyle};
-
-  width: 4.4rem;
-  height: 2.2rem;
-
-  display: flex;
-  justify-content: center;
+  border-top-style: ${({ $borderTopStyle }) => $borderTopStyle};
+  ${({ $defaultSlotStyle }) => $defaultSlotStyle};
+  ${({ $customSlotStyle }) => $customSlotStyle};
 `;

--- a/src/components/timetableComponents/parts/Slot.tsx
+++ b/src/components/timetableComponents/parts/Slot.tsx
@@ -31,7 +31,7 @@ function Slot({ slotId, customSlotStyle, slotUnit, onClick, children }: SlotProp
       $customSlotStyle={customSlotStyle}
       onClick={onClick}
     >
-      {children}
+      <PriorityNumber>{children}</PriorityNumber>
     </SlotWrapper>
   );
 }
@@ -47,4 +47,13 @@ const SlotWrapper = styled.div<{
   border-top-style: ${({ $borderTopStyle }) => $borderTopStyle};
   ${({ $defaultSlotStyle }) => $defaultSlotStyle};
   ${({ $customSlotStyle }) => $customSlotStyle};
+`;
+
+const PriorityNumber = styled.div`
+  display: flex;
+  position: relative;
+  top: 6px;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
 `;

--- a/src/components/timetableComponents/parts/Slot.tsx
+++ b/src/components/timetableComponents/parts/Slot.tsx
@@ -4,15 +4,14 @@ import styled from 'styled-components';
 
 interface SlotProps {
   customSlotStyle?: string;
-  slotUnit: 'HALF' | 'HOUR';
   onClick?: () => void;
   children?: ReactNode;
 }
 
-function Slot({ customSlotStyle, slotUnit, onClick, children }: SlotProps) {
+function Slot({ customSlotStyle, onClick, children }: SlotProps) {
   const defaultSlotStyle = `
     width: 4.4rem;
-    height: ${slotUnit === 'HALF' ? '2.2rem' : '1.2rem'};
+    height: 2.2rem;
     display: flex;
     justify-content: center;
   `;

--- a/src/components/timetableComponents/parts/SlotTitle.tsx
+++ b/src/components/timetableComponents/parts/SlotTitle.tsx
@@ -18,10 +18,10 @@ function SlotTitle({ timeSlots, slotUnit }: SlotTitleProps) {
     <SlotTitleWrapper $slotUnit={slotUnit}>
       {parsedTimeSlots.map((slot) => (
         <Fragment key={slot}>
-          <Text font="body4" color={theme.colors.grey5} key={`${slot}-fill`}>
+          <Text font="body4" color={theme.colors.grey7} key={`${slot}-fill`}>
             {slot}
           </Text>
-          <Text font="body4" color={theme.colors.grey5} key={`${slot}-empty`}>
+          <Text font="body4" color={theme.colors.grey7} key={`${slot}-empty`}>
             {''}
           </Text>
         </Fragment>

--- a/src/components/timetableComponents/parts/SlotTitle.tsx
+++ b/src/components/timetableComponents/parts/SlotTitle.tsx
@@ -4,18 +4,18 @@ import Text from 'components/atomComponents/Text';
 import styled from 'styled-components';
 import { theme } from 'styles/theme';
 
-interface SlotTitleProps {
-  timeSlots: string[];
-}
+import { TimetableProps } from '../Timetable';
 
-function SlotTitle({ timeSlots }: SlotTitleProps) {
+type SlotTitleProps = Pick<TimetableProps, 'timeSlots' | 'slotUnit'>;
+
+function SlotTitle({ timeSlots, slotUnit }: SlotTitleProps) {
   const parsedTimeSlots = timeSlots
     .filter((slot) => !slot.endsWith('30'))
     .map((slot) => parseInt(slot.split(':')[0]));
   parsedTimeSlots.push(24);
 
   return (
-    <SlotTitleWrapper>
+    <SlotTitleWrapper $slotUnit={slotUnit}>
       {parsedTimeSlots.map((slot) => (
         <Fragment key={slot}>
           <Text font="body4" color={theme.colors.grey5} key={`${slot}-fill`}>
@@ -32,9 +32,9 @@ function SlotTitle({ timeSlots }: SlotTitleProps) {
 
 export default SlotTitle;
 
-const SlotTitleWrapper = styled.div`
+const SlotTitleWrapper = styled.div<{ $slotUnit: 'HALF' | 'HOUR' }>`
   display: flex;
   flex-direction: column;
-  gap: 1.4rem;
+  gap: ${({ $slotUnit }) => ($slotUnit === 'HALF' ? '1.4rem' : '0.4rem')};
   margin-top: 3.3rem;
 `;

--- a/src/components/timetableComponents/types.ts
+++ b/src/components/timetableComponents/types.ts
@@ -8,6 +8,7 @@ export interface TimetableStructure extends BaseStructure {
 
 export interface ColumnStructure extends BaseStructure {
   date: string;
+  slotUnit: 'HALF' | 'HOUR';
 }
 
 export interface DateType {

--- a/src/components/timetableComponents/types.ts
+++ b/src/components/timetableComponents/types.ts
@@ -8,7 +8,6 @@ export interface TimetableStructure extends BaseStructure {
 
 export interface ColumnStructure extends BaseStructure {
   date: string;
-  slotUnit: 'HALF' | 'HOUR';
 }
 
 export interface DateType {

--- a/src/pages/loginEntrance/components/MemberComponent.tsx
+++ b/src/pages/loginEntrance/components/MemberComponent.tsx
@@ -1,16 +1,16 @@
 import React, { Dispatch, SetStateAction } from 'react';
 
+import { userNameAtom } from 'atoms/atom';
 import Button from 'components/atomComponents/Button';
-import Header from 'components/moleculesComponents/Header';
 import Text from 'components/atomComponents/Text';
 import TextInput from 'components/atomComponents/TextInput';
+import Header from 'components/moleculesComponents/Header';
 import TitleComponent from 'components/moleculesComponents/TitleComponents';
+import { useParams } from 'react-router';
+import { useNavigate } from 'react-router-dom';
+import { useRecoilState } from 'recoil';
 import styled from 'styled-components/macro';
 import { theme } from 'styles/theme';
-import { useNavigate } from 'react-router-dom';
-import { useParams } from 'react-router';
-import { useRecoilState } from 'recoil';
-import { userNameAtom } from 'atoms/atom';
 
 interface HostInfoProps {
   name: string;

--- a/src/pages/overallSchedule/components/OverallScheduleColumn.tsx
+++ b/src/pages/overallSchedule/components/OverallScheduleColumn.tsx
@@ -24,9 +24,13 @@ function OverallScheduleColumn({ date, timeSlots, availableSlotInfo }: OverallSc
     };
 
     const isClickedSlot = clickedSlot === slotId;
+    const borderStyle = slotId.endsWith(':30') ? 'none' : 'solid';
+    const borderTop = `1px ${borderStyle} ${theme.colors.grey7} `;
+
     return `
       background-color: ${isClickedSlot && colorLevel!==0 ? theme.colors.sub1 : COLOR[colorLevel]};
       cursor: ${colorLevel !== 0 ? 'pointer' : 'default'};
+      border-top: ${borderTop};
     `
   }
 
@@ -36,7 +40,7 @@ function OverallScheduleColumn({ date, timeSlots, availableSlotInfo }: OverallSc
         const { colorLevel = 0, userNames = [] } = availableSlotInfo.find((info) => info.time === timeSlot) ?? {};
         const slotId = `${date}/${timeSlot}`;
 
-        return <Slot key={slotId} slotId={slotId} slotStyle={getTimeSlotStyle(colorLevel, slotId)} onClick={()=>onClickSlot(slotId, userNames)}/>;
+        return <Slot key={slotId} slotUnit='HALF' customSlotStyle={getTimeSlotStyle(colorLevel, slotId)} onClick={()=>onClickSlot(slotId, userNames)}/>;
       })}
     </>
   );

--- a/src/pages/overallSchedule/components/OverallScheduleColumn.tsx
+++ b/src/pages/overallSchedule/components/OverallScheduleColumn.tsx
@@ -24,7 +24,7 @@ function OverallScheduleColumn({ date, timeSlots, availableSlotInfo }: OverallSc
     };
 
     /**
-     * 우선순위 입력 스타일링
+     * 종합일정 시간표 스타일링
      * 1. border-top: 선택된 시간이라면 none, 선택되지 않은 시간이라면 30분 단위는 none, 1시간 단위는 실선
      * 2. background-color: 선택된 시간이라면 colorLevel에 따른 색상
      */

--- a/src/pages/overallSchedule/components/OverallScheduleColumn.tsx
+++ b/src/pages/overallSchedule/components/OverallScheduleColumn.tsx
@@ -23,14 +23,20 @@ function OverallScheduleColumn({ date, timeSlots, availableSlotInfo }: OverallSc
       5: theme.colors.level5,
     };
 
+    /**
+     * 우선순위 입력 스타일링
+     * 1. border-top: 선택된 시간이라면 none, 선택되지 않은 시간이라면 30분 단위는 none, 1시간 단위는 실선
+     * 2. background-color: 선택된 시간이라면 colorLevel에 따른 색상
+     */
+    const borderTopStyle = slotId.endsWith(':30') ? 'none' : 'solid';
+    const borderTop = `1px ${borderTopStyle} ${theme.colors.grey7} `;
     const isClickedSlot = clickedSlot === slotId;
-    const borderStyle = slotId.endsWith(':30') ? 'none' : 'solid';
-    const borderTop = `1px ${borderStyle} ${theme.colors.grey7} `;
+    const backgroundColor = isClickedSlot && colorLevel !== 0 ? theme.colors.sub1 : COLOR[colorLevel];
 
     return `
-      background-color: ${isClickedSlot && colorLevel!==0 ? theme.colors.sub1 : COLOR[colorLevel]};
-      cursor: ${colorLevel !== 0 ? 'pointer' : 'default'};
       border-top: ${borderTop};
+      background-color: ${backgroundColor};
+      cursor: ${colorLevel !== 0 ? 'pointer' : 'default'};
     `
   }
 

--- a/src/pages/overallSchedule/components/OverallScheduleColumn.tsx
+++ b/src/pages/overallSchedule/components/OverallScheduleColumn.tsx
@@ -46,7 +46,7 @@ function OverallScheduleColumn({ date, timeSlots, availableSlotInfo }: OverallSc
         const { colorLevel = 0, userNames = [] } = availableSlotInfo.find((info) => info.time === timeSlot) ?? {};
         const slotId = `${date}/${timeSlot}`;
 
-        return <Slot key={slotId} slotUnit='HALF' customSlotStyle={getTimeSlotStyle(colorLevel, slotId)} onClick={()=>onClickSlot(slotId, userNames)}/>;
+        return <Slot key={slotId} customSlotStyle={getTimeSlotStyle(colorLevel, slotId)} onClick={()=>onClickSlot(slotId, userNames)}/>;
       })}
     </>
   );

--- a/src/pages/overallSchedule/components/OverallScheduleTable.tsx
+++ b/src/pages/overallSchedule/components/OverallScheduleTable.tsx
@@ -46,11 +46,17 @@ function OverallScheduleTable({
         setClickedUserNames,
       }}
     >
-      <Timetable timeSlots={timeSlots} availableDates={availableDates} bottomItem={<UserNames />}>
+      <Timetable
+        timeSlots={timeSlots}
+        availableDates={availableDates}
+        slotUnit="HALF"
+        bottomItem={<UserNames />}
+      >
         {({ date, timeSlots }: ColumnStructure) => (
           <OverallScheduleColumn
             date={date}
             timeSlots={timeSlots}
+            slotUnit="HALF"
             availableSlotInfo={getAvailableTimesPerDate(
               dataOverallSchedule.availableDateTimes,
               date,

--- a/src/pages/overallSchedule/components/OverallScheduleTable.tsx
+++ b/src/pages/overallSchedule/components/OverallScheduleTable.tsx
@@ -56,7 +56,6 @@ function OverallScheduleTable({
           <OverallScheduleColumn
             date={date}
             timeSlots={timeSlots}
-            slotUnit="HALF"
             availableSlotInfo={getAvailableTimesPerDate(
               dataOverallSchedule.availableDateTimes,
               date,

--- a/src/pages/selectSchedule/components/SelectScheduleTable.tsx
+++ b/src/pages/selectSchedule/components/SelectScheduleTable.tsx
@@ -18,12 +18,14 @@ function SelectScheduleTable({ timeSlots, availableDates }: TimetableStructure) 
 
   const { scheduleStep } = useScheduleStepContext();
 
+  const slotUnit = scheduleStep === 'selectTimeSlot' ? 'HALF' : 'HOUR';
+
   const stepColumns: StepSlotsType = {
     selectTimeSlot: ({ date, timeSlots }: ColumnStructure) => (
-      <SelectionColumn date={date} timeSlots={timeSlots} />
+      <SelectionColumn date={date} timeSlots={timeSlots} slotUnit={slotUnit} />
     ),
     selectPriority: ({ date, timeSlots }: ColumnStructure) => (
-      <PriorityColumn date={date} timeSlots={timeSlots} />
+      <PriorityColumn date={date} timeSlots={timeSlots} slotUnit={slotUnit} />
     ),
   };
   const stepColumn = stepColumns[scheduleStep];
@@ -48,7 +50,12 @@ function SelectScheduleTable({ timeSlots, availableDates }: TimetableStructure) 
         setSelectedSlots,
       }}
     >
-      <Timetable timeSlots={timeSlots} availableDates={availableDates} bottomItem={bottomItem}>
+      <Timetable
+        timeSlots={timeSlots}
+        availableDates={availableDates}
+        slotUnit={slotUnit}
+        bottomItem={bottomItem}
+      >
         {stepColumn}
       </Timetable>
     </SelectContext.Provider>

--- a/src/pages/selectSchedule/components/SelectScheduleTable.tsx
+++ b/src/pages/selectSchedule/components/SelectScheduleTable.tsx
@@ -22,10 +22,10 @@ function SelectScheduleTable({ timeSlots, availableDates }: TimetableStructure) 
 
   const stepColumns: StepSlotsType = {
     selectTimeSlot: ({ date, timeSlots }: ColumnStructure) => (
-      <SelectionColumn date={date} timeSlots={timeSlots} slotUnit={slotUnit} />
+      <SelectionColumn date={date} timeSlots={timeSlots} />
     ),
     selectPriority: ({ date, timeSlots }: ColumnStructure) => (
-      <PriorityColumn date={date} timeSlots={timeSlots} slotUnit={slotUnit} />
+      <PriorityColumn date={date} timeSlots={timeSlots} />
     ),
   };
   const stepColumn = stepColumns[scheduleStep];

--- a/src/pages/selectSchedule/components/selectPriority/PriorityColumn.tsx
+++ b/src/pages/selectSchedule/components/selectPriority/PriorityColumn.tsx
@@ -40,13 +40,18 @@ function PriorityColumn({ date, timeSlots, slotUnit }: ColumnStructure) {
             ? theme.colors.main3
             : theme.colors.grey6;
 
-    const borderStyle = slotId.endsWith(':30') ? 'none' : 'solid';
+    /**
+     * 우선순위 입력 스타일링
+     * 1. border-top: 선택된 시간이라면 none, 선택되지 않은 시간이라면 30분 단위는 none, 1시간 단위는 실선
+     * 2. background-color: 선택된 시간이라면 우선순위에 따른 slotColor
+     */
+    const borderTopStyle = slotId.endsWith(':30') ? 'none' : 'solid';
+    const borderTop = isSelectedSlot ? 'none' : `1px ${borderTopStyle} ${theme.colors.grey7}`;
     const backgroundColor = isSelectedSlot ? slotColor : 'transparent';
-    const borderTop = isSelectedSlot ? 'none' : `1px ${borderStyle} ${theme.colors.grey7}`;
 
     return `
-        background-color : ${backgroundColor};
         border-top: ${borderTop};
+        background-color : ${backgroundColor};
     `;
   };
 

--- a/src/pages/selectSchedule/components/selectPriority/PriorityColumn.tsx
+++ b/src/pages/selectSchedule/components/selectPriority/PriorityColumn.tsx
@@ -5,7 +5,7 @@ import { theme } from 'styles/theme';
 
 import Slot from '../../../../components/timetableComponents/parts/Slot';
 
-function PriorityColumn({ date, timeSlots }: ColumnStructure) {
+function PriorityColumn({ date, timeSlots, slotUnit }: ColumnStructure) {
   const { selectedSlots } = useSelectContext();
 
   const selectedSlotsPerDate = Object.entries(selectedSlots).filter(
@@ -67,7 +67,8 @@ function PriorityColumn({ date, timeSlots }: ColumnStructure) {
           <Slot
             key={slotId}
             slotId={slotId}
-            slotStyle={getPriorityColumnStyle(priority, selectedEntryId)}
+            slotUnit={slotUnit}
+            customSlotStyle={getPriorityColumnStyle(priority, selectedEntryId)}
           >
             <Text font="body1" color={theme.colors.white}>
               {isFirstSlot && priority !== 0 ? changePriorityValue(priority) : ''}

--- a/src/pages/selectSchedule/components/selectPriority/PriorityColumn.tsx
+++ b/src/pages/selectSchedule/components/selectPriority/PriorityColumn.tsx
@@ -5,7 +5,7 @@ import { theme } from 'styles/theme';
 
 import Slot from '../../../../components/timetableComponents/parts/Slot';
 
-function PriorityColumn({ date, timeSlots, slotUnit }: ColumnStructure) {
+function PriorityColumn({ date, timeSlots }: ColumnStructure) {
   const { selectedSlots } = useSelectContext();
 
   const selectedSlotsPerDate = Object.entries(selectedSlots).filter(
@@ -48,10 +48,12 @@ function PriorityColumn({ date, timeSlots, slotUnit }: ColumnStructure) {
     const borderTopStyle = slotId.endsWith(':30') ? 'none' : 'solid';
     const borderTop = isSelectedSlot ? 'none' : `1px ${borderTopStyle} ${theme.colors.grey7}`;
     const backgroundColor = isSelectedSlot ? slotColor : 'transparent';
+    const height = '1.2rem';
 
     return `
         border-top: ${borderTop};
-        background-color : ${backgroundColor};
+        background-color: ${backgroundColor};
+        height: ${height};
     `;
   };
 
@@ -76,7 +78,6 @@ function PriorityColumn({ date, timeSlots, slotUnit }: ColumnStructure) {
         return (
           <Slot
             key={slotId}
-            slotUnit={slotUnit}
             customSlotStyle={getPriorityColumnStyle(slotId, priority, selectedEntryId)}
           >
             <Text font="body1" color={theme.colors.white}>

--- a/src/pages/selectSchedule/components/selectPriority/PriorityColumn.tsx
+++ b/src/pages/selectSchedule/components/selectPriority/PriorityColumn.tsx
@@ -24,8 +24,12 @@ function PriorityColumn({ date, timeSlots, slotUnit }: ColumnStructure) {
         throw Error(`올바르지않은 priority ${priority}`);
     }
   };
-  const getPriorityColumnStyle = (priority: number, selectedEntryId: number | null) => {
-    const isSelectedSlot = selectedEntryId;
+  const getPriorityColumnStyle = (
+    slotId: string,
+    priority: number,
+    selectedEntryId: number | null,
+  ) => {
+    const isSelectedSlot = selectedEntryId !== null;
 
     const slotColor =
       priority === 3
@@ -36,13 +40,13 @@ function PriorityColumn({ date, timeSlots, slotUnit }: ColumnStructure) {
             ? theme.colors.main3
             : theme.colors.grey6;
 
+    const borderStyle = slotId.endsWith(':30') ? 'none' : 'solid';
+    const backgroundColor = isSelectedSlot ? slotColor : 'transparent';
+    const borderTop = isSelectedSlot ? 'none' : `1px ${borderStyle} ${theme.colors.grey7}`;
+
     return `
-        ${
-          isSelectedSlot !== null
-            ? `background-color:${slotColor}`
-            : `background-color: transparent`
-        };
-        ${isSelectedSlot !== null && 'border-top-style: none'};
+        background-color : ${backgroundColor};
+        border-top: ${borderTop};
     `;
   };
 
@@ -67,9 +71,8 @@ function PriorityColumn({ date, timeSlots, slotUnit }: ColumnStructure) {
         return (
           <Slot
             key={slotId}
-            slotId={slotId}
             slotUnit={slotUnit}
-            customSlotStyle={getPriorityColumnStyle(priority, selectedEntryId)}
+            customSlotStyle={getPriorityColumnStyle(slotId, priority, selectedEntryId)}
           >
             <Text font="body1" color={theme.colors.white}>
               {isFirstSlot && priority !== 0 ? changePriorityValue(priority) : ''}

--- a/src/pages/selectSchedule/components/selectPriority/PriorityColumn.tsx
+++ b/src/pages/selectSchedule/components/selectPriority/PriorityColumn.tsx
@@ -41,7 +41,8 @@ function PriorityColumn({ date, timeSlots, slotUnit }: ColumnStructure) {
           isSelectedSlot !== null
             ? `background-color:${slotColor}`
             : `background-color: transparent`
-        }
+        };
+        ${isSelectedSlot !== null && 'border-top-style: none'};
     `;
   };
 

--- a/src/pages/selectSchedule/components/selectTimeSlot/SelectionColumn.tsx
+++ b/src/pages/selectSchedule/components/selectTimeSlot/SelectionColumn.tsx
@@ -17,6 +17,12 @@ function SelectionColumn({ date, timeSlots, slotUnit }: ColumnStructure) {
     const isStartSlot = slotId === startSlot;
     const isSelectedSlot = selectedEntryId !== undefined;
 
+    /**
+     * 가능시간 입력 시간표 스타일링
+     * 1. border-top: 30분 단위는 dashed, 1시간 단위는 solid
+     * 2. border: 탭투탭 시 startSlot에 dashed
+     * 3. background-color: 탭투탭으로 선택된 시간이면 main1, 그 외는 transparent;
+     */
     const borderStyle = slotId.endsWith(':30') ? 'dashed' : 'solid';
     const border = isStartSlot && `1px dashed ${theme.colors.main5}`;
     const borderTop = `1px ${borderStyle} ${theme.colors.grey7}`;
@@ -25,7 +31,7 @@ function SelectionColumn({ date, timeSlots, slotUnit }: ColumnStructure) {
     return `
       cursor:pointer;
       border-top: ${borderTop};
-      border: ${border};
+      ${isStartSlot && `border: ${border}`};
       background-color: ${backgroundColor};
     `;
   };

--- a/src/pages/selectSchedule/components/selectTimeSlot/SelectionColumn.tsx
+++ b/src/pages/selectSchedule/components/selectTimeSlot/SelectionColumn.tsx
@@ -17,12 +17,16 @@ function SelectionColumn({ date, timeSlots, slotUnit }: ColumnStructure) {
     const isStartSlot = slotId === startSlot;
     const isSelectedSlot = selectedEntryId !== undefined;
 
+    const borderStyle = slotId.endsWith(':30') ? 'dashed' : 'solid';
+    const border = isStartSlot && `1px dashed ${theme.colors.main5}`;
+    const borderTop = `1px ${borderStyle} ${theme.colors.grey7}`;
+    const backgroundColor = isSelectedSlot ? theme.colors.main1 : 'transparent';
+
     return `
       cursor:pointer;
-      ${isStartSlot && `border: 1px dashed ${theme.colors.main5}`};
-      ${
-        isSelectedSlot ? `background-color: ${theme.colors.main1}` : `background-color: transparent`
-      };
+      border-top: ${borderTop};
+      border: ${border};
+      background-color: ${backgroundColor};
     `;
   };
 
@@ -38,7 +42,6 @@ function SelectionColumn({ date, timeSlots, slotUnit }: ColumnStructure) {
         return (
           <Slot
             key={slotId}
-            slotId={slotId}
             slotUnit={slotUnit}
             customSlotStyle={getTimeSlotStyle(slotId, selectedEntryId)}
             onClick={() => onClickSlot(slotId, selectedEntryId)}

--- a/src/pages/selectSchedule/components/selectTimeSlot/SelectionColumn.tsx
+++ b/src/pages/selectSchedule/components/selectTimeSlot/SelectionColumn.tsx
@@ -16,23 +16,30 @@ function SelectionColumn({ date, timeSlots }: ColumnStructure) {
   const getTimeSlotStyle = (slotId: string, selectedEntryId?: number) => {
     const isStartSlot = slotId === startSlot;
     const isSelectedSlot = selectedEntryId !== undefined;
+    const isFirstSlot =
+      selectedEntryId !== undefined &&
+      selectedSlots[selectedEntryId].startSlot === slotId.split('/')[3];
 
     /**
      * 가능시간 입력 시간표 스타일링
      * 1. border-top: 30분 단위는 dashed, 1시간 단위는 solid
      * 2. border: 탭투탭 시 startSlot에 dashed
-     * 3. background-color: 탭투탭으로 선택된 시간이면 main1, 그 외는 transparent;
+     * 3. background-color: 선택된 시간이면서 맨 첫번째 Slot이라면 그라디언트, 그 외는 main1, 선택된 시간이 아니면 transparent;
      */
     const borderStyle = slotId.endsWith(':30') ? 'dashed' : 'solid';
     const border = isStartSlot && `1px dashed ${theme.colors.main5}`;
     const borderTop = `1px ${borderStyle} ${theme.colors.grey7}`;
-    const backgroundColor = isSelectedSlot ? theme.colors.main1 : 'transparent';
+    const background = isSelectedSlot
+      ? isFirstSlot
+        ? 'linear-gradient(180deg, #496AFF 0%, #3253FF 75%)'
+        : theme.colors.main1
+      : 'transparent';
 
     return `
       cursor:pointer;
       border-top: ${borderTop};
       ${isStartSlot && `border: ${border}`};
-      background-color: ${backgroundColor};
+      background: ${background};
     `;
   };
 

--- a/src/pages/selectSchedule/components/selectTimeSlot/SelectionColumn.tsx
+++ b/src/pages/selectSchedule/components/selectTimeSlot/SelectionColumn.tsx
@@ -5,7 +5,7 @@ import { theme } from 'styles/theme';
 import useSlotSeletion from './hooks/useSlotSelection';
 import Slot from '../../../../components/timetableComponents/parts/Slot';
 
-function SelectionColumn({ date, timeSlots }: ColumnStructure) {
+function SelectionColumn({ date, timeSlots, slotUnit }: ColumnStructure) {
   const { selectedSlots } = useSelectContext();
   const selectedSlotsPerDate = Object.entries(selectedSlots).filter(
     ([, slot]) => slot.date === date,
@@ -39,7 +39,8 @@ function SelectionColumn({ date, timeSlots }: ColumnStructure) {
           <Slot
             key={slotId}
             slotId={slotId}
-            slotStyle={getTimeSlotStyle(slotId, selectedEntryId)}
+            slotUnit={slotUnit}
+            customSlotStyle={getTimeSlotStyle(slotId, selectedEntryId)}
             onClick={() => onClickSlot(slotId, selectedEntryId)}
           />
         );

--- a/src/pages/selectSchedule/components/selectTimeSlot/SelectionColumn.tsx
+++ b/src/pages/selectSchedule/components/selectTimeSlot/SelectionColumn.tsx
@@ -5,7 +5,7 @@ import { theme } from 'styles/theme';
 import useSlotSeletion from './hooks/useSlotSelection';
 import Slot from '../../../../components/timetableComponents/parts/Slot';
 
-function SelectionColumn({ date, timeSlots, slotUnit }: ColumnStructure) {
+function SelectionColumn({ date, timeSlots }: ColumnStructure) {
   const { selectedSlots } = useSelectContext();
   const selectedSlotsPerDate = Object.entries(selectedSlots).filter(
     ([, slot]) => slot.date === date,
@@ -48,7 +48,6 @@ function SelectionColumn({ date, timeSlots, slotUnit }: ColumnStructure) {
         return (
           <Slot
             key={slotId}
-            slotUnit={slotUnit}
             customSlotStyle={getTimeSlotStyle(slotId, selectedEntryId)}
             onClick={() => onClickSlot(slotId, selectedEntryId)}
           />

--- a/src/pages/selectSchedule/utils.ts
+++ b/src/pages/selectSchedule/utils.ts
@@ -25,6 +25,7 @@ export const TITLES: TitlesType = {
   },
   selectPriority: {
     main: '우선순위를 입력해주세요',
+    sub: '선호하는 회의시간대 최대 3순위까지 입력해주세요',
   },
 } as const;
 


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 🌀 해당 이슈 번호

- close #287

## 🔹 어떤 것을 변경했나요?

- [x] recoil-persist로 참여자 이름 저장

## 🔹 어떻게 구현했나요?

참여자 이름을 저장하는 atom에 recoil-persist를 적용했습니다
```js
export const userNameAtom = atom<string>({
  key: 'userNameAtom',
  default: '',
  effects_UNSTABLE: [persistAtom],
});
```
recoil-persist는 해당 정보를 local-storage에 저장해주는 기능입니다.
그래서 참여자 이름을 입력하면 다음과같이 loca-storage에 저장되고
새로 입력할때마다 값이 대체됩니다.
![image](https://github.com/user-attachments/assets/0a34b4a4-08cc-4dba-a714-18f6b3930135)


## 🔹 PR 포인트를 알려주세요!
일단 빠르고 간단한 해결책인 recoil-persist로 해결을 하긴했지만
전역 상태관리에 대해 전반적으로 리팩토링이 필요할것같습니다.

## 🔹 스크린샷을 남겨주세요!
