### PR TITLE
feat: recoil-persist 적용

### DIFF
--- a/src/atoms/atom.ts
+++ b/src/atoms/atom.ts
@@ -1,7 +1,7 @@
-import { DateStates, ScheduleStates, TimeStates } from 'pages/legacy/selectSchedule/types/Schedule';
-
 import { PreferTime } from 'components/legacy/scheduleComponents/types/AvailableScheduleType';
+import { DateStates, ScheduleStates } from 'pages/legacy/selectSchedule/types/Schedule';
 import { atom } from 'recoil';
+import { recoilPersist } from 'recoil-persist';
 
 export const methodStateAtom = atom<boolean>({
   key: 'methodStateAtom',
@@ -41,7 +41,10 @@ export const clickedTimeSlotAtom = atom<string>({
   default: undefined,
 });
 
+const { persistAtom } = recoilPersist();
+
 export const userNameAtom = atom<string>({
   key: 'userNameAtom',
   default: '',
+  effects_UNSTABLE: [persistAtom],
 });


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 🌀 해당 이슈 번호

- close #287

## 🔹 어떤 것을 변경했나요?

- [x] recoil-persist로 참여자 이름 저장

## 🔹 어떻게 구현했나요?

참여자 이름을 저장하는 atom에 recoil-persist를 적용했습니다
```js
export const userNameAtom = atom<string>({
  key: 'userNameAtom',
  default: '',
  effects_UNSTABLE: [persistAtom],
});
```
recoil-persist는 해당 정보를 local-storage에 저장해주는 기능입니다.
그래서 참여자 이름을 입력하면 다음과같이 loca-storage에 저장되고
새로 입력할때마다 값이 대체됩니다.
![image](https://github.com/user-attachments/assets/0a34b4a4-08cc-4dba-a714-18f6b3930135)


## 🔹 PR 포인트를 알려주세요!
일단 빠르고 간단한 해결책인 recoil-persist로 해결을 하긴했지만
전역 상태관리에 대해 전반적으로 리팩토링이 필요할것같습니다.

## 🔹 스크린샷을 남겨주세요!
