### PR TITLE
[Fix/#318] 방장 및 참여자 이름 입력 제한 글자수 8자로 변경

### DIFF
--- a/src/components/common/atomComponents/TextInput.tsx
+++ b/src/components/common/atomComponents/TextInput.tsx
@@ -41,7 +41,7 @@ function TextInput({ value, setValue, resetValue, max, placeholder }: ValueProps
           value.length > max && (
             <SubTextSection>
               <Text font={'body4'} color={`${theme.colors.red}`}>
-                `공백포함 최대 ${String(max)}자까지 입력가능해요`
+                {`공백포함 최대 ${String(max)}자까지 입력가능해요`}
               </Text>
             </SubTextSection>
           )}

--- a/src/components/common/atomComponents/TextInput.tsx
+++ b/src/components/common/atomComponents/TextInput.tsx
@@ -9,10 +9,11 @@ interface ValueProps {
   value: string;
   setValue: (e: React.ChangeEvent<HTMLInputElement>) => void;
   resetValue: () => void;
+  max: number;
   placeholder: string;
 }
 
-function TextInput({ value, setValue, resetValue, placeholder }: ValueProps) {
+function TextInput({ value, setValue, resetValue, max, placeholder }: ValueProps) {
   const [focus, setFocus] = useState(false);
 
   const resetOnClick = () => {
@@ -28,19 +29,19 @@ function TextInput({ value, setValue, resetValue, placeholder }: ValueProps) {
             value={value}
             onChange={setValue}
             onFocus={() => setFocus(true)}
-            $iserror={value?.length > 15}
+            $iserror={value?.length > max}
           />
           {focus && (
             <IconContainer onClick={resetOnClick}>
-              {value && value.length > 15 ? <InputErrorIc /> : <InputCancelIc />}
+              {value && value.length > max ? <InputErrorIc /> : <InputCancelIc />}
             </IconContainer>
           )}
         </InputSection>
         {value &&
-          value.length > 15 && (
+          value.length > max && (
             <SubTextSection>
               <Text font={'body4'} color={`${theme.colors.red}`}>
-                공백포함 최대 15자까지 입력가능해요
+                `공백포함 최대 ${String(max)}자까지 입력가능해요`
               </Text>
             </SubTextSection>
           )}

--- a/src/pages/createMeeting/components/useFunnel/SetHostInfo.tsx
+++ b/src/pages/createMeeting/components/useFunnel/SetHostInfo.tsx
@@ -55,7 +55,7 @@ function SetHostInfo({ meetingInfo, setMeetingInfo, setStep }: FunnelProps) {
             value={meetingInfo.name}
             setValue={hostOnChange}
             resetValue={resetHost}
-            max={6}
+            max={8}
             placeholder={'방장 이름'}
           />
         </HostNameSection>

--- a/src/pages/createMeeting/components/useFunnel/SetHostInfo.tsx
+++ b/src/pages/createMeeting/components/useFunnel/SetHostInfo.tsx
@@ -55,6 +55,7 @@ function SetHostInfo({ meetingInfo, setMeetingInfo, setStep }: FunnelProps) {
             value={meetingInfo.name}
             setValue={hostOnChange}
             resetValue={resetHost}
+            max={6}
             placeholder={'방장 이름'}
           />
         </HostNameSection>

--- a/src/pages/createMeeting/components/useFunnel/SetTitle.tsx
+++ b/src/pages/createMeeting/components/useFunnel/SetTitle.tsx
@@ -24,6 +24,7 @@ function SetTitle({ meetingInfo, setMeetingInfo, setStep }: FunnelProps) {
         value={meetingInfo.title}
         setValue={titleOnChange}
         resetValue={resetTitle}
+        max={15}
         placeholder={'서비스 기획 1차 회의'}
       />
       <StyledBtnSection>

--- a/src/pages/loginEntrance/components/HostComponent.tsx
+++ b/src/pages/loginEntrance/components/HostComponent.tsx
@@ -87,6 +87,7 @@ function HostComponent({ hostInfo, setHostInfo }: HostProps) {
             value={hostInfo.name}
             setValue={hostOnChange}
             resetValue={resetHostId}
+            max={6}
             placeholder={'방장 이름'}
           />
         </HostNameSection>

--- a/src/pages/loginEntrance/components/HostComponent.tsx
+++ b/src/pages/loginEntrance/components/HostComponent.tsx
@@ -87,7 +87,7 @@ function HostComponent({ hostInfo, setHostInfo }: HostProps) {
             value={hostInfo.name}
             setValue={hostOnChange}
             resetValue={resetHostId}
-            max={6}
+            max={8}
             placeholder={'방장 이름'}
           />
         </HostNameSection>

--- a/src/pages/loginEntrance/components/MemberComponent.tsx
+++ b/src/pages/loginEntrance/components/MemberComponent.tsx
@@ -57,6 +57,7 @@ function MemberComponent({ hostInfo, setHostInfo }: HostProps) {
             value={hostInfo.name}
             setValue={hostOnChange}
             resetValue={resetHostId}
+            max={6}
             placeholder={'참여자 이름'}
           />
         </HostNameSection>

--- a/src/pages/loginEntrance/components/MemberComponent.tsx
+++ b/src/pages/loginEntrance/components/MemberComponent.tsx
@@ -57,7 +57,7 @@ function MemberComponent({ hostInfo, setHostInfo }: HostProps) {
             value={hostInfo.name}
             setValue={hostOnChange}
             resetValue={resetHostId}
-            max={6}
+            max={8}
             placeholder={'참여자 이름'}
           />
         </HostNameSection>


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 🌀 해당 이슈 번호

- close #318

## 🔹 어떤 것을 변경했나요?

- [x] TextInput 컴포넌트에서 max값을 prop으로 받도록 변경
- [x] 방장 정보 입력 이름 제한 16자 -> 8자로 변경
- [x] 참여자 정보 입력 이름 제한 16자 -> 8자로 변경

## 🔹 어떻게 구현했나요?
기존에 TextInput 공통컴포넌트에서, 글자수 제한을 15자로 하드코딩되어있었습니다.
TextInput이 쓰이는 곳마다 글자수 제한을 다르게 줄 필요가 있기 때문에 이 값을 prop으로 추가했습니다.

그리고 참여자 정보 입력 input과 방장 정보 입력 input에서 max값을 8자로 넘겨주도록 구현했습니다.

## 🔹 PR 포인트를 알려주세요!

## 🔹 스크린샷을 남겨주세요!

https://github.com/user-attachments/assets/a40702c1-9f55-4b22-a9ed-bd9248379075

