### PR TITLE
[Feat/#323] 430기준으로 반응형 뷰 적용

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,6 @@ import './utils/changeBrowser';
 import { useEffect } from 'react';
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import styled, { ThemeProvider } from 'styled-components';
 import ToastContainerBox from 'utils/toast/ToastContainer';
 
@@ -60,7 +59,7 @@ function App() {
             <Router />
             <ToastContainerBox />
           </MobileWrapper>
-          <ReactQueryDevtools initialIsOpen={false} />
+          {/* <ReactQueryDevtools initialIsOpen={false} /> */}
         </QueryClientProvider>
       </ThemeProvider>
     </>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,13 @@
 /**카카오톡 인앱브라우저 종료후 크롬 및 사파리로 오픈하는 utils file */
-import './utils/changeBrowser';
 import 'react-toastify/dist/ReactToastify.css';
 import './App.css';
+import './utils/changeBrowser';
 
 import { useEffect } from 'react';
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
-import { ThemeProvider } from 'styled-components';
-import styled from 'styled-components';
+import styled, { ThemeProvider } from 'styled-components';
 import ToastContainerBox from 'utils/toast/ToastContainer';
 
 import Router from './Router';
@@ -27,7 +26,7 @@ const MobileWrapper = styled.div`
   padding-right: 2rem;
   padding-left: 2rem;
 
-  max-width: var(--app-max-width, 37.5rem);
+  max-width: var(--app-max-width, 43.5rem);
   min-height: calc(var(--vh, 1vh) * 100);
 `;
 
@@ -37,7 +36,8 @@ function App() {
     document.documentElement.style.setProperty('--vh', `${vh}px`);
 
     const windowWidth = window.innerWidth || document.documentElement.clientWidth;
-    const maxWidth = Math.min(37.5, windowWidth);
+
+    const maxWidth = Math.min(43, windowWidth);
     document.documentElement.style.setProperty('--app-max-width', `${maxWidth}rem`);
   };
 

--- a/src/components/common/BottomSheet/BottomSheet.tsx
+++ b/src/components/common/BottomSheet/BottomSheet.tsx
@@ -34,7 +34,7 @@ const BottomSheetModal = styled.div<{ $isModalOpen: boolean }>`
 
   padding: 4.4rem 2rem 4rem;
   width: 100%;
-  max-width: 41rem;
+  max-width: 43rem;
 
   & button {
     width: 100%;

--- a/src/components/common/BottomSheet/BottomSheet.tsx
+++ b/src/components/common/BottomSheet/BottomSheet.tsx
@@ -34,7 +34,7 @@ const BottomSheetModal = styled.div<{ $isModalOpen: boolean }>`
 
   padding: 4.4rem 2rem 4rem;
   width: 100%;
-  max-width: 39rem;
+  max-width: 41rem;
 
   & button {
     width: 100%;

--- a/src/components/common/BottomSheet/BottomSheet.tsx
+++ b/src/components/common/BottomSheet/BottomSheet.tsx
@@ -33,7 +33,8 @@ const BottomSheetModal = styled.div<{ $isModalOpen: boolean }>`
   background-color: ${({ theme }) => theme.colors.grey8};
 
   padding: 4.4rem 2rem 4rem;
-  width: 37.5rem;
+  width: 100%;
+  max-width: 39rem;
 
   & button {
     width: 100%;

--- a/src/components/common/atomComponents/Button.tsx
+++ b/src/components/common/atomComponents/Button.tsx
@@ -58,6 +58,7 @@ const buttonCSS = {
     ${buttonDefaultCSS.basicCss};
     background: ${({ theme }) => theme.colors.grey7};
     color: ${({ theme }) => theme.colors.grey4};
+    cursor: default;
   `,
   secondaryActive: css`
     ${buttonDefaultCSS.basicCss};

--- a/src/components/common/atomComponents/Button.tsx
+++ b/src/components/common/atomComponents/Button.tsx
@@ -1,6 +1,6 @@
-import { css, styled } from 'styled-components';
-
 import React from 'react';
+
+import { css, styled } from 'styled-components';
 
 interface ButtonProps {
   children: React.ReactNode;
@@ -27,7 +27,8 @@ const buttonDefaultCSS = {
 
     border-radius: 0.8rem;
     padding: 1.6rem;
-    width: 33.5rem;
+    width: 100%;
+    max-width: 39rem;
     height: 5.4rem;
     letter-spacing: -0.032rem;
 

--- a/src/components/common/atomComponents/Button.tsx
+++ b/src/components/common/atomComponents/Button.tsx
@@ -45,7 +45,8 @@ const buttonCSS = {
   halfPrimaryActive: css`
     ${buttonDefaultCSS.basicCss};
     background: ${({ theme }) => theme.colors.main1};
-    width: 15.2rem;
+    /* width: 15.2rem;     width: calc((100%-14px) / 2);*/
+    max-width: 18.8rem;
     color: ${({ theme }) => theme.colors.white};
   `,
   halfPrimaryDisabled: css`
@@ -68,7 +69,8 @@ const buttonCSS = {
   halfSecondaryActive: css`
     ${buttonDefaultCSS.basicCss};
     background: ${({ theme }) => theme.colors.main5};
-    width: 15.2rem;
+    /* width: 15.2rem; */
+    max-width: 18.8rem;
     color: ${({ theme }) => theme.colors.grey9};
   `,
   secondaryDisabled: css`

--- a/src/components/common/atomComponents/Button.tsx
+++ b/src/components/common/atomComponents/Button.tsx
@@ -45,7 +45,7 @@ const buttonCSS = {
   halfPrimaryActive: css`
     ${buttonDefaultCSS.basicCss};
     background: ${({ theme }) => theme.colors.main1};
-    /* width: 15.2rem;     width: calc((100%-14px) / 2);*/
+    width: 100%;
     max-width: 18.8rem;
     color: ${({ theme }) => theme.colors.white};
   `,
@@ -53,6 +53,7 @@ const buttonCSS = {
     ${buttonDefaultCSS.basicCss};
     background: ${({ theme }) => theme.colors.grey7};
     max-width: 18.8rem;
+    width: 100%;
     color: ${({ theme }) => theme.colors.grey4};
   `,
   primaryDisabled: css`
@@ -69,7 +70,6 @@ const buttonCSS = {
   halfSecondaryActive: css`
     ${buttonDefaultCSS.basicCss};
     background: ${({ theme }) => theme.colors.main5};
-    /* width: 15.2rem; */
     max-width: 18.8rem;
     color: ${({ theme }) => theme.colors.grey9};
   `,
@@ -78,6 +78,7 @@ const buttonCSS = {
     background: ${({ theme }) => theme.colors.grey7};
     color: ${({ theme }) => theme.colors.grey5};
     pointer-events: none;
+    cursor: default;
   `,
   halfsecondaryDisabled: css`
     ${buttonDefaultCSS.basicCss};

--- a/src/components/common/atomComponents/Button.tsx
+++ b/src/components/common/atomComponents/Button.tsx
@@ -31,7 +31,7 @@ const buttonDefaultCSS = {
     max-width: 39rem;
     height: 5.4rem;
     letter-spacing: -0.032rem;
-    margin: 0 2rem;
+    /* margin: 0 2rem; */
     pointer-events: auto;
   `,
 };

--- a/src/components/common/atomComponents/Button.tsx
+++ b/src/components/common/atomComponents/Button.tsx
@@ -52,7 +52,7 @@ const buttonCSS = {
   halfPrimaryDisabled: css`
     ${buttonDefaultCSS.basicCss};
     background: ${({ theme }) => theme.colors.grey7};
-    width: 15.2rem;
+    max-width: 18.8rem;
     color: ${({ theme }) => theme.colors.grey4};
   `,
   primaryDisabled: css`
@@ -82,7 +82,7 @@ const buttonCSS = {
   halfsecondaryDisabled: css`
     ${buttonDefaultCSS.basicCss};
     background: ${({ theme }) => theme.colors.grey7};
-    width: 15.2rem;
+    max-width: 18.8rem;
     color: ${({ theme }) => theme.colors.grey5};
   `,
   tertiaryActive: css`
@@ -95,7 +95,7 @@ const buttonCSS = {
     ${buttonDefaultCSS.basicCss};
     border: 1px solid ${({ theme }) => theme.colors.main3};
     background-color: ${({ theme }) => theme.colors.grey10};
-    width: 15.2rem;
+    max-width: 18.8rem;
     color: ${({ theme }) => theme.colors.main3};
   `,
   tertiaryDisabled: css`

--- a/src/components/common/atomComponents/Button.tsx
+++ b/src/components/common/atomComponents/Button.tsx
@@ -31,7 +31,7 @@ const buttonDefaultCSS = {
     max-width: 39rem;
     height: 5.4rem;
     letter-spacing: -0.032rem;
-
+    margin: 0 2rem;
     pointer-events: auto;
   `,
 };

--- a/src/components/common/atomComponents/PasswordInput.tsx
+++ b/src/components/common/atomComponents/PasswordInput.tsx
@@ -25,7 +25,7 @@ function PasswordInput({ value, placeholder, passWordOnChange, page }: ValueProp
           placeholder={placeholder}
           value={value}
           onChange={passWordOnChange}
-          $iserror={value.length < 4}
+          $iserror={value.length < 4 || value.length > 8}
           type={inputType ? 'password' : `number`}
           inputMode="numeric"
         />
@@ -34,15 +34,25 @@ function PasswordInput({ value, placeholder, passWordOnChange, page }: ValueProp
         </IconContainer>
       </InputSection>
       {page === 'createMeeting' ? (
-        <SubTextSection>
-          <Text font={'body4'} color={`${theme.colors.sub1}`}>
-            *
-          </Text>
-          <Text font={'body4'} color={`${theme.colors.sub1}`}>
-            확정 후 비밀번호는 수정할 수 없으며, 비밀번호가 있어야 방장 페이지에 접속할 수 있으니
-            반드시 기억해주세요!
-          </Text>
-        </SubTextSection>
+        <>
+          {value.length > 8 && (
+            <InvalidPWTextSection>
+              <Text font={'body4'} color={theme.colors.red}>
+                최대 8자리까지 입력 가능해요{' '}
+              </Text>
+            </InvalidPWTextSection>
+          )}
+
+          <SubTextSection>
+            <Text font={'body4'} color={`${theme.colors.sub1}`}>
+              *
+            </Text>
+            <Text font={'body4'} color={`${theme.colors.sub1}`}>
+              확정 후 비밀번호는 수정할 수 없으며, 비밀번호가 있어야 방장 페이지에 접속할 수 있으니
+              반드시 기억해주세요!
+            </Text>
+          </SubTextSection>
+        </>
       ) : (
         undefined
       )}
@@ -112,6 +122,14 @@ const SubTextSection = styled.div`
   gap: 0.4rem;
   align-items: flex-start;
   margin-top: 1.7rem;
+
+  span {
+    font-weight: 600;
+  }
+`;
+
+const InvalidPWTextSection = styled.div`
+  margin-top: 0.9rem;
 
   span {
     font-weight: 600;

--- a/src/components/common/atomComponents/PasswordInput.tsx
+++ b/src/components/common/atomComponents/PasswordInput.tsx
@@ -78,7 +78,7 @@ const StyledPasswordInput = styled.input<{ $iserror: boolean }>`
   background: ${({ theme }) => theme.colors.grey7};
   padding: 1rem 1.6rem;
 
-  width: 33.5rem;
+  width: 100%;
   height: 5.2rem;
 
   caret-color: ${({ theme }) => theme.colors.main1};

--- a/src/components/common/atomComponents/PlaceInput.tsx
+++ b/src/components/common/atomComponents/PlaceInput.tsx
@@ -51,7 +51,9 @@ function PlaceInput({ value, setValue, placeholder }: ValueProps) {
 
 export default PlaceInput;
 
-const PlaceInputWrapper = styled.div``;
+const PlaceInputWrapper = styled.div`
+  width: 100%;
+`;
 
 const InputSection = styled.div`
   display: flex;
@@ -78,7 +80,7 @@ const StyledTextInput = styled.input<{ $iserror: boolean }>`
 
   padding: 1rem 1.6rem;
 
-  width: 33.5rem;
+  width: 100%;
   height: 5.2rem;
 
   color: ${({ theme }) => theme.colors.white};

--- a/src/components/common/atomComponents/TextAreaInput.tsx
+++ b/src/components/common/atomComponents/TextAreaInput.tsx
@@ -24,6 +24,7 @@ function TextAreaInput({ value, setValue, placeholder }: ValueProps) {
 export default TextAreaInput;
 
 const TextAreaWrapper = styled.div`
+  width: 100%;
   position: relative;
 `;
 
@@ -32,7 +33,7 @@ const StyledTextArea = styled.textarea`
   border-radius: 1rem;
   background-color: ${({ theme }) => theme.colors.grey8};
   padding: 1.8rem;
-  width: 33.5rem;
+  width: 100%;
   height: 20.8rem;
   resize: none;
   color: ${({ theme }) => theme.colors.white};

--- a/src/components/common/atomComponents/TextInput.tsx
+++ b/src/components/common/atomComponents/TextInput.tsx
@@ -20,7 +20,7 @@ function TextInput({ value, setValue, resetValue, placeholder }: ValueProps) {
     setFocus(false);
   };
   return (
-    <>
+
       <TextInputWrapper>
         <InputSection>
           <StyledTextInput
@@ -45,19 +45,23 @@ function TextInput({ value, setValue, resetValue, placeholder }: ValueProps) {
             </SubTextSection>
           )}
       </TextInputWrapper>
-    </>
+
   );
 }
 
 export default TextInput;
 
-const TextInputWrapper = styled.div``;
+const TextInputWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+`;
 
 const InputSection = styled.div`
   display: flex;
   position: relative;
   flex-direction: column;
-
+width: 100%;
   input:focus + div {
     display: flex;
     svg {
@@ -77,7 +81,8 @@ const StyledTextInput = styled.input<{ $iserror: boolean }>`
   background: ${({ theme }) => theme.colors.grey7};
   padding: 1rem 1.6rem;
 
-  width: 33.5rem;
+  width: 100%;
+  max-width: 39rem;
   height: 5.2rem;
 
   color: ${({ theme }) => theme.colors.white};

--- a/src/components/common/moleculesComponents/BottomBtnSection.tsx
+++ b/src/components/common/moleculesComponents/BottomBtnSection.tsx
@@ -1,0 +1,22 @@
+import { ReactNode } from 'react';
+
+import styled from 'styled-components';
+
+interface BottomBtnProps {
+  children: ReactNode;
+}
+
+const BottomBtnSection = ({ children }: BottomBtnProps) => {
+  return <ButtomBtnWrapper>{children}</ButtomBtnWrapper>;
+};
+
+const ButtomBtnWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  position: fixed;
+  bottom: 1.2rem;
+  padding: 0 2rem;
+  gap: 1.4rem;
+`;
+export default BottomBtnSection;

--- a/src/components/common/timetableComponents/Timetable.tsx
+++ b/src/components/common/timetableComponents/Timetable.tsx
@@ -45,6 +45,7 @@ export default Timetable;
 
 const TimetableWrapper = styled.div`
   display: flex;
+  justify-content: center;
   width: 100%;
   gap: 1.1rem;
 `;

--- a/src/pages/bestMeetTime/ChooseBestTime.tsx
+++ b/src/pages/bestMeetTime/ChooseBestTime.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import Header from 'components/common/moleculesComponents/Header';
 import BestMeetTime from 'pages/bestMeetTime/components/BestMeetTime';
@@ -38,6 +38,7 @@ const ViewPickerWrapper = styled.div`
 `;
 
 const ChangeViewPicker = styled.div<{ $isClicked: boolean }>`
+  cursor: pointer;
   display: flex;
   justify-content: center;
   margin-top: 2.5rem;

--- a/src/pages/bestMeetTime/ChooseBestTime.tsx
+++ b/src/pages/bestMeetTime/ChooseBestTime.tsx
@@ -74,6 +74,7 @@ const ChangeViewPicker = styled.div<{ $isClicked: boolean }>`
 const ViewContainer = styled.div`
   display: flex;
   align-items: center;
+  justify-content: center;
   width: 100%;
   margin-top: 3.6rem;
   margin-bottom: 16.4rem;

--- a/src/pages/bestMeetTime/components/BestMeetTime.tsx
+++ b/src/pages/bestMeetTime/components/BestMeetTime.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 
 import Button from 'components/common/atomComponents/Button';
 import Text from 'components/common/atomComponents/Text';
+import BottomBtnSection from 'components/common/moleculesComponents/BottomBtnSection';
 import { DropDown, DropUp } from 'components/Icon/icon';
 import BestTimeCard from 'pages/bestMeetTime/components/BestTimeCard';
 import ConfirmModal from 'pages/bestMeetTime/components/ConfirmModal';
@@ -104,11 +105,11 @@ function BestMeetTime() {
           ) : null}
         </AlternativeSection>
       ) : null}
-      <BtnWrapper>
+      <BottomBtnSection>
         <Button typeState={'primaryActive'} onClick={() => setShowModal(true)}>
           <Text font={'title2'}> 확정</Text>
         </Button>
-      </BtnWrapper>
+      </BottomBtnSection>
       {showModal &&
         bestMeetimeObj && (
           <ConfirmModal

--- a/src/pages/bestMeetTime/components/BestMeetTime.tsx
+++ b/src/pages/bestMeetTime/components/BestMeetTime.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import Button from 'components/common/atomComponents/Button';
 import Text from 'components/common/atomComponents/Text';
@@ -168,6 +168,7 @@ const BasicIconContainer = styled.div`
   height: 3rem;
 `;
 const BtnWrapper = styled.div`
+  width: 100%;
   position: fixed;
   bottom: 1.2rem;
   border-radius: 50%;

--- a/src/pages/bestMeetTime/components/BestMeetTime.tsx
+++ b/src/pages/bestMeetTime/components/BestMeetTime.tsx
@@ -129,7 +129,10 @@ const LoadingWrapper = styled.div`
   width: 100%;
 `;
 const BestMeetTimeWrapper = styled.div<{ $state: boolean }>`
+  display: flex;
+  flex-direction: column;
   width: 100%;
+  align-items: center;
 `;
 const TitleSection = styled.article`
   display: flex;
@@ -158,6 +161,7 @@ const AlternativeSection = styled.section`
   display: flex;
   flex-direction: column;
   gap: 1.6rem;
+  width: 100%;
 `;
 const BasicIconContainer = styled.div`
   display: flex;
@@ -168,8 +172,9 @@ const BasicIconContainer = styled.div`
   height: 3rem;
 `;
 const BtnWrapper = styled.div`
+  display: flex;
+  justify-content: center;
   width: 100%;
   position: fixed;
   bottom: 1.2rem;
-  border-radius: 50%;
 `;

--- a/src/pages/bestMeetTime/components/BestMeetTime.tsx
+++ b/src/pages/bestMeetTime/components/BestMeetTime.tsx
@@ -21,14 +21,14 @@ function BestMeetTime() {
   const [selected, setSelected] = useState(0);
   const [showModal, setShowModal] = useState<boolean>(false);
   const { meetingId } = useParams();
-  const { isloading, bestTimeData, isError } = GetBestMeetimeListHooks(
+  const { isLoading, bestTimeData, isError } = GetBestMeetimeListHooks(
     (meetingId as unknown) as string,
   );
   const navigate = useNavigate();
   if (isError) {
     navigate(`/*`);
   }
-  if (isloading) {
+  if (isLoading) {
     return (
       <LoadingWrapper>
         <LoadingPage />
@@ -124,6 +124,8 @@ function BestMeetTime() {
 export default BestMeetTime;
 
 const LoadingWrapper = styled.div`
+  display: flex;
+  justify-content: center;
   position: relative;
   top: 25rem;
   width: 100%;

--- a/src/pages/bestMeetTime/components/BestTimeCard.tsx
+++ b/src/pages/bestMeetTime/components/BestTimeCard.tsx
@@ -47,6 +47,7 @@ const BestTimeCardWrapper = styled.article<{ $rank: number; $selected: number }>
   display: flex;
   position: relative;
   flex-direction: row;
+  align-items: center;
   border: 1px solid
     ${({ $rank, $selected, theme }) =>
       $rank === $selected ? theme.colors.main1 : theme.colors.grey7};

--- a/src/pages/bestMeetTime/components/BlankMeetCard.tsx
+++ b/src/pages/bestMeetTime/components/BlankMeetCard.tsx
@@ -15,6 +15,7 @@ function BlankMeetCard() {
 export default BlankMeetCard;
 
 const BlankMeetCardWrapper = styled.div`
+  width: 100%;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/pages/bestMeetTime/hooks/getBestMeetimeList.ts
+++ b/src/pages/bestMeetTime/hooks/getBestMeetimeList.ts
@@ -6,7 +6,7 @@ import { DateTimeData } from '../types/meetCardData';
 
 const GetBestMeetimeListHooks = (meetingId: string) => {
   const [isError, setIsError] = useState(false);
-  const [isloading, setIsloading] = useState(true);
+  const [isLoading, setIsloading] = useState(true);
   const [bestTimeData, setBestTimeData] = useState<DateTimeData>();
 
   const getBestMeetimeList = async () => {
@@ -27,7 +27,7 @@ const GetBestMeetimeListHooks = (meetingId: string) => {
     },
     [meetingId],
   );
-  return { isloading, bestTimeData, isError };
+  return { isLoading, bestTimeData, isError };
 };
 
 export default GetBestMeetimeListHooks;

--- a/src/pages/completeCreateMeeting/CompleteCreateMeeting.tsx
+++ b/src/pages/completeCreateMeeting/CompleteCreateMeeting.tsx
@@ -37,6 +37,9 @@ const CompleteCreateMeeting = () => {
 export default CompleteCreateMeeting;
 
 const BtnWrapper = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: center;
   position: absolute;
   bottom: 1.2rem;
 `;

--- a/src/pages/completeCreateMeeting/CompleteCreateMeeting.tsx
+++ b/src/pages/completeCreateMeeting/CompleteCreateMeeting.tsx
@@ -1,6 +1,7 @@
 import stepingCheck from 'assets/images/steppingCheck.png';
 import Button from 'components/common/atomComponents/Button';
 import Text from 'components/common/atomComponents/Text';
+import BottomBtnSection from 'components/common/moleculesComponents/BottomBtnSection';
 import CheckPoint from 'components/common/moleculesComponents/CheckPoint';
 import Header from 'components/common/moleculesComponents/Header';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -24,11 +25,11 @@ const CompleteCreateMeeting = () => {
         mainText={'회의 생성 완료!'}
         subText={'이제 나의 가능 시간을 입력하러 가볼까요?'}
       />
-      <BtnWrapper>
+      <BottomBtnSection>
         <Button typeState={'primaryActive'} onClick={navigateSelectSchedule}>
           <Text font={'button2'}>나의 가능 시간 입력</Text>
         </Button>
-      </BtnWrapper>
+      </BottomBtnSection>
       <CreateMeetingBottomSheet />
     </CompleteCreateMeetingWrapper>
   );
@@ -36,13 +37,6 @@ const CompleteCreateMeeting = () => {
 
 export default CompleteCreateMeeting;
 
-const BtnWrapper = styled.div`
-  width: 100%;
-  display: flex;
-  justify-content: center;
-  position: absolute;
-  bottom: 1.2rem;
-`;
 const CompleteCreateMeetingWrapper = styled.div`
   display: flex;
   flex-direction: column;

--- a/src/pages/createMeeting/components/useFunnel/SetAdditionalInfo.tsx
+++ b/src/pages/createMeeting/components/useFunnel/SetAdditionalInfo.tsx
@@ -6,6 +6,7 @@ import Text from 'components/common/atomComponents/Text';
 import TextAreaInput from 'components/common/atomComponents/TextAreaInput';
 import BottomSheet from 'components/common/BottomSheet/BottomSheet';
 import useModalState from 'components/common/Modal/hooks/useModalState';
+import BottomBtnSection from 'components/common/moleculesComponents/BottomBtnSection';
 import { durationType, placeType, weekDayType } from 'pages/createMeeting/data/meetingInfoData';
 import { FunnelProps, MeetingInfo } from 'pages/createMeeting/types/useFunnelInterface';
 import { useNavigate } from 'react-router-dom';
@@ -65,7 +66,7 @@ function SetAdditionalInfo({ meetingInfo, setMeetingInfo }: FunnelProps) {
           setValue={textAreaOnChange}
           placeholder={'회의 안건, 준비물 등 회의와 관련하여 알리고 싶은 추가 내용을 적어 보세요.'}
         />
-        <StyledBtnWrapper>
+        <BottomBtnSection>
           <Button
             typeState={meetingInfo.additionalInfo ? 'primaryActive' : 'tertiaryActive'}
             onClick={onOpen}
@@ -74,7 +75,7 @@ function SetAdditionalInfo({ meetingInfo, setMeetingInfo }: FunnelProps) {
               {meetingInfo.additionalInfo ? `회의방 생성하기` : `건너뛰기`}
             </Text>
           </Button>
-        </StyledBtnWrapper>
+        </BottomBtnSection>
       </SetAdditionalInfoWrapper>
       <BottomSheet isOpen={isOpen}>
         <BottomSheetDescription>
@@ -142,15 +143,6 @@ width:100%;
   display: flex;
   align-items: center;
   justify-content: center;
-`;
-
-const StyledBtnWrapper = styled.section`
-  width:100%;
-  display: flex;
-  justify-content:center;
-  position: fixed;
-  bottom: 1.2rem;
-  border-radius: 50%;
 `;
 
 const BottomSheetDescription = styled.div`

--- a/src/pages/createMeeting/components/useFunnel/SetAdditionalInfo.tsx
+++ b/src/pages/createMeeting/components/useFunnel/SetAdditionalInfo.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 
 import { isAxiosError } from 'axios';
 import Button from 'components/common/atomComponents/Button';
@@ -138,12 +138,16 @@ function SetAdditionalInfo({ meetingInfo, setMeetingInfo }: FunnelProps) {
 export default SetAdditionalInfo;
 
 const SetAdditionalInfoWrapper = styled.div`
+width:100%;
   display: flex;
   align-items: center;
   justify-content: center;
 `;
 
 const StyledBtnWrapper = styled.section`
+  width:100%;
+  display: flex;
+  justify-content:center;
   position: fixed;
   bottom: 1.2rem;
   border-radius: 50%;

--- a/src/pages/createMeeting/components/useFunnel/SetDates.css
+++ b/src/pages/createMeeting/components/useFunnel/SetDates.css
@@ -29,7 +29,7 @@
 }
 
 .rmdp-calendar {
-  width: 36rem;
+  width: 100%;
   height: 37.9rem;
 }
 
@@ -38,7 +38,7 @@
 }
 
 .rmdp-day-picker > div {
-  width: 36rem;
+  width: 100%;
 }
 
 .rmdp-day-picker > div > div:first-child {
@@ -154,10 +154,10 @@
   pointer-events: none !important;
 }
 .rmdp-day {
-  width: 4rem;
-  height: 4rem;
+  width: 5rem;
+  height: 5rem;
   /*날짜*/
-  padding: 2.5rem 2.5rem;
+  padding: 2.7rem 2.7rem;
 }
 .rmdp-day span {
   font-weight: 400;
@@ -173,7 +173,7 @@
 
 .rmdp-week-day {
   /*요일*/
-  width: 4rem;
+  width: 5.4rem !important;
   height: 4rem;
   padding: 0 0.4rem;
 }

--- a/src/pages/createMeeting/components/useFunnel/SetDates.css
+++ b/src/pages/createMeeting/components/useFunnel/SetDates.css
@@ -197,3 +197,7 @@
 .rmdp-day.rmdp-disabled.rmdp-deactive {
   color: var(--rmdp-grey10) !important;
 }
+
+.rmdp-header-values.rmdp-header-values span {
+  padding: 0px;
+}

--- a/src/pages/createMeeting/components/useFunnel/SetDates.css
+++ b/src/pages/createMeeting/components/useFunnel/SetDates.css
@@ -43,7 +43,7 @@
 
 .rmdp-day-picker > div > div:first-child {
   margin-bottom: 0.7rem;
-  border-bottom: 0.5px solid white;
+  /* border-bottom: 0.5px solid white; */
 }
 
 /* .rmdp-week {

--- a/src/pages/createMeeting/components/useFunnel/SetDates.tsx
+++ b/src/pages/createMeeting/components/useFunnel/SetDates.tsx
@@ -76,6 +76,11 @@ function SetDates({ meetingInfo, setMeetingInfo, setStep }: FunnelProps) {
             shadow={false}
             showOtherDays
             weekDays={weekDays}
+            headerOrder={['YEAR_MONTH']}
+            // formatYear={(year, month) => {
+            //   return 'Year' + year;
+            // }}
+            monthYearSeparator={'년 '}
             className="bg-dark"
             range={!multiple}
             multiple={multiple}

--- a/src/pages/createMeeting/components/useFunnel/SetDates.tsx
+++ b/src/pages/createMeeting/components/useFunnel/SetDates.tsx
@@ -155,18 +155,22 @@ const SetDatesWrapper = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
+  width: 100%;
 `;
 
 const StyledBtnSection = styled.section`
+  display: flex;
+  justify-content: center;
   position: fixed;
   bottom: 1.2rem;
-  z-index: 3;
+  width: 100%;
 `;
 const DateSelectorWrapper = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  width: 100%;
 `;
 
 const RangeInputBox = styled.div<{ $isClicked: boolean }>`
@@ -177,7 +181,7 @@ const RangeInputBox = styled.div<{ $isClicked: boolean }>`
   border-radius: 0.8rem;
   border-color: ${({ $isClicked, theme }) =>
     $isClicked ? theme.colors.grey5 : theme.colors.main1};
-  width: 33.5rem;
+  width: 100%;
   height: 5.2rem;
 
   color: ${({ theme }) => theme.colors.white};
@@ -202,7 +206,7 @@ const Label = styled.label`
   align-items: center;
   margin-left: 1.2rem;
   height: 5rem;
-  width: 28rem;
+
   ${({ theme }) => theme.fonts.button1};
   color: ${({ theme }) => theme.colors.grey6};
 `;
@@ -216,7 +220,7 @@ const MultipleInputBox = styled.div<{ $isClicked: boolean }>`
   border-color: ${({ $isClicked, theme }) =>
     $isClicked ? theme.colors.main1 : theme.colors.grey5};
   background-color: transparent;
-  width: 33.5rem;
+  width: 100%;
   height: 5.2rem;
   color: ${({ theme }) => theme.colors.white};
 `;
@@ -224,7 +228,7 @@ const MultipleInputBox = styled.div<{ $isClicked: boolean }>`
 const InputContianer = styled.div`
   display: flex;
   flex-direction: column;
-  align-items: left;
+  width: 100%;
   margin-bottom: 3rem;
   div:first-child {
     margin-bottom: 1.1rem;

--- a/src/pages/createMeeting/components/useFunnel/SetDates.tsx
+++ b/src/pages/createMeeting/components/useFunnel/SetDates.tsx
@@ -27,7 +27,6 @@ const months = [
 const weekDays = ['일', '월', '화', '수', '목', '금', '토'];
 const dateRangeFormat = 'YYYY/MM/DD/ddd';
 function SetDates({ meetingInfo, setMeetingInfo, setStep }: FunnelProps) {
-  // const [multiple, setMultiple] = useState(false);
   const [multiple, setMultiple] = useRecoilState(methodStateAtom);
   return (
     <SetDatesWrapper>
@@ -76,10 +75,7 @@ function SetDates({ meetingInfo, setMeetingInfo, setStep }: FunnelProps) {
             shadow={false}
             showOtherDays
             weekDays={weekDays}
-            headerOrder={['YEAR_MONTH']}
-            // formatYear={(year, month) => {
-            //   return 'Year' + year;
-            // }}
+            headerOrder={['LEFT_BUTTON', 'YEAR_MONTH', 'RIGHT_BUTTON']}
             monthYearSeparator={'년 '}
             className="bg-dark"
             range={!multiple}

--- a/src/pages/createMeeting/components/useFunnel/SetDates.tsx
+++ b/src/pages/createMeeting/components/useFunnel/SetDates.tsx
@@ -5,6 +5,7 @@ import './SetDates.css';
 import { methodStateAtom } from 'atoms/atom';
 import Button from 'components/common/atomComponents/Button';
 import Text from 'components/common/atomComponents/Text';
+import BottomBtnSection from 'components/common/moleculesComponents/BottomBtnSection';
 import { FunnelProps, MeetingInfo } from 'pages/createMeeting/types/useFunnelInterface';
 import { Calendar, DateObject, getAllDatesInRange } from 'react-multi-date-picker';
 import { useRecoilState } from 'recoil';
@@ -118,7 +119,7 @@ function SetDates({ meetingInfo, setMeetingInfo, setStep }: FunnelProps) {
           />
         </CalendarWrapper>
       </DateSelectorWrapper>
-      <StyledBtnSection>
+      <BottomBtnSection>
         <Button
           typeState={
             (meetingInfo.availableDates.length > 1 && meetingInfo.availableDates.length < 8) ||
@@ -145,7 +146,7 @@ function SetDates({ meetingInfo, setMeetingInfo, setStep }: FunnelProps) {
         >
           <Text font={'button2'}>다음</Text>
         </Button>
-      </StyledBtnSection>
+      </BottomBtnSection>
     </SetDatesWrapper>
   );
 }
@@ -159,13 +160,6 @@ const SetDatesWrapper = styled.div`
   width: 100%;
 `;
 
-const StyledBtnSection = styled.section`
-  display: flex;
-  justify-content: center;
-  position: fixed;
-  bottom: 1.2rem;
-  width: 100%;
-`;
 const DateSelectorWrapper = styled.div`
   display: flex;
   flex-direction: column;

--- a/src/pages/createMeeting/components/useFunnel/SetDates.tsx
+++ b/src/pages/createMeeting/components/useFunnel/SetDates.tsx
@@ -185,16 +185,17 @@ const RangeInputBox = styled.div<{ $isClicked: boolean }>`
   width: 100%;
   height: 5.2rem;
 
+  cursor: pointer;
   color: ${({ theme }) => theme.colors.white};
 `;
 const Input = styled.input`
   appearance: none;
-  margin: 1.5rem 0 1.5rem 1.6rem;
   background-image: url("data:image/svg+xml,%3Csvg width='22' height='22' viewBox='0 0 22 22' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Ccircle cx='11' cy='11' r='10' stroke='%23D9D9D9' stroke-width='2'/%3E%3C/svg%3E%0A");
   background-repeat: no-repeat;
-  width: 2.2rem;
+  width: 3.2rem;
   height: 2.2rem;
-
+  margin-left: 1.5rem;
+  cursor: pointer;
   &:checked {
     background-image: url("data:image/svg+xml,%3Csvg width='22' height='22' viewBox='0 0 22 22' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Ccircle cx='11' cy='11' r='11' fill='%233C49FF'/%3E%3Ccircle cx='11' cy='11' r='4' fill='white'/%3E%3C/svg%3E ");
   }
@@ -205,9 +206,10 @@ const Input = styled.input`
 const Label = styled.label`
   display: flex;
   align-items: center;
-  margin-left: 1.2rem;
+  padding: 0 1.2rem;
   height: 5rem;
-
+  width: 100%;
+  cursor: pointer;
   ${({ theme }) => theme.fonts.button1};
   color: ${({ theme }) => theme.colors.grey6};
 `;

--- a/src/pages/createMeeting/components/useFunnel/SetDuration.tsx
+++ b/src/pages/createMeeting/components/useFunnel/SetDuration.tsx
@@ -55,11 +55,14 @@ const SetAdditionalInfoWrapper = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
+  width: 100%;
 `;
 
 const DurationWrapper = styled.div`
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr); /* 3열로 나누기 */
+  grid-template-rows: repeat(3, 1fr); /* 2행으로 나누기 */
+  width: 100%;
   gap: 1.1rem;
 
   justify-content: center;

--- a/src/pages/createMeeting/components/useFunnel/SetDuration.tsx
+++ b/src/pages/createMeeting/components/useFunnel/SetDuration.tsx
@@ -1,5 +1,6 @@
 import Button from 'components/common/atomComponents/Button';
 import Text from 'components/common/atomComponents/Text';
+import BottomBtnSection from 'components/common/moleculesComponents/BottomBtnSection';
 import { durationType } from 'pages/createMeeting/data/meetingInfoData';
 import { FunnelProps, MeetingInfo } from 'pages/createMeeting/types/useFunnelInterface';
 import styled from 'styled-components';
@@ -26,7 +27,7 @@ function SetDuration({ meetingInfo, setMeetingInfo, setStep }: FunnelProps) {
           );
         })}
       </DurationWrapper>
-      <StyledBtnWrapper>
+      <BottomBtnSection>
         <Button
           typeState={meetingInfo.duration ? 'primaryActive' : 'primaryDisabled'}
           onClick={
@@ -43,7 +44,7 @@ function SetDuration({ meetingInfo, setMeetingInfo, setStep }: FunnelProps) {
         >
           <Text font={'button2'}>다음</Text>
         </Button>
-      </StyledBtnWrapper>
+      </BottomBtnSection>
     </SetAdditionalInfoWrapper>
   );
 }
@@ -54,14 +55,6 @@ const SetAdditionalInfoWrapper = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-`;
-
-const StyledBtnWrapper = styled.section`
-  width: 100%;
-  display: flex;
-  justify-content: center;
-  position: fixed;
-  bottom: 1.2rem;
 `;
 
 const DurationWrapper = styled.div`

--- a/src/pages/createMeeting/components/useFunnel/SetDuration.tsx
+++ b/src/pages/createMeeting/components/useFunnel/SetDuration.tsx
@@ -57,6 +57,9 @@ const SetAdditionalInfoWrapper = styled.div`
 `;
 
 const StyledBtnWrapper = styled.section`
+  width: 100%;
+  display: flex;
+  justify-content: center;
   position: fixed;
   bottom: 1.2rem;
 `;

--- a/src/pages/createMeeting/components/useFunnel/SetHostInfo.tsx
+++ b/src/pages/createMeeting/components/useFunnel/SetHostInfo.tsx
@@ -25,7 +25,7 @@ function SetHostInfo({ meetingInfo, setMeetingInfo, setStep }: FunnelProps) {
       if (e.target.value.length < 9) {
         return { ...prev, password: e.target.value };
       }
-      alert('비밀번호는 8자리 이하로 말해주세요');
+      alert('비밀번호는 8자리 이하로 설정해주세요.');
       return { ...prev };
     });
   };
@@ -99,6 +99,9 @@ const SetHostInfoWrapper = styled.div`
 `;
 
 const StyledBtnSection = styled.section`
+  display: flex;
+  justify-content: center;
+  width: 100%;
   position: fixed;
   bottom: 1.2rem;
   border-radius: 50%;
@@ -113,5 +116,4 @@ const HostInfoSection = styled.div`
   display: flex;
   flex-direction: column;
   gap: 3.4rem;
-  padding: 0 2rem;
 `;

--- a/src/pages/createMeeting/components/useFunnel/SetHostInfo.tsx
+++ b/src/pages/createMeeting/components/useFunnel/SetHostInfo.tsx
@@ -4,6 +4,7 @@ import Button from 'components/common/atomComponents/Button';
 import PasswordInput from 'components/common/atomComponents/PasswordInput';
 import Text from 'components/common/atomComponents/Text';
 import TextInput from 'components/common/atomComponents/TextInput';
+import BottomBtnSection from 'components/common/moleculesComponents/BottomBtnSection';
 import { FunnelProps, MeetingInfo } from 'pages/createMeeting/types/useFunnelInterface';
 import styled from 'styled-components';
 import { theme } from 'styles/theme';
@@ -70,7 +71,7 @@ function SetHostInfo({ meetingInfo, setMeetingInfo, setStep }: FunnelProps) {
           />
         </HostNameSection>
       </HostInfoSection>
-      <StyledBtnSection>
+      <BottomBtnSection>
         <Button
           typeState={
             meetingInfo.name && meetingInfo.password.length >= 4
@@ -85,7 +86,7 @@ function SetHostInfo({ meetingInfo, setMeetingInfo, setStep }: FunnelProps) {
         >
           <Text font={'button2'}>다음</Text>
         </Button>
-      </StyledBtnSection>
+      </BottomBtnSection>
     </SetHostInfoWrapper>
   );
 }
@@ -96,15 +97,6 @@ const SetHostInfoWrapper = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-`;
-
-const StyledBtnSection = styled.section`
-  display: flex;
-  justify-content: center;
-  width: 100%;
-  position: fixed;
-  bottom: 1.2rem;
-  border-radius: 50%;
 `;
 
 const HostNameSection = styled.section`

--- a/src/pages/createMeeting/components/useFunnel/SetHostInfo.tsx
+++ b/src/pages/createMeeting/components/useFunnel/SetHostInfo.tsx
@@ -23,11 +23,7 @@ function SetHostInfo({ meetingInfo, setMeetingInfo, setStep }: FunnelProps) {
 
   const passWordOnChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setMeetingInfo((prev: MeetingInfo) => {
-      if (e.target.value.length < 9) {
-        return { ...prev, password: e.target.value };
-      }
-      alert('비밀번호는 8자리 이하로 설정해주세요.');
-      return { ...prev };
+      return { ...prev, password: e.target.value };
     });
   };
 
@@ -43,6 +39,15 @@ function SetHostInfo({ meetingInfo, setMeetingInfo, setStep }: FunnelProps) {
     } else {
       alert('비밀번호는 4자리 이상 숫자로만 이루어져야합니다');
     }
+  };
+
+  const validateForm = () => {
+    return (
+      meetingInfo.name &&
+      meetingInfo.name.length <= 15 &&
+      meetingInfo.password.length >= 4 &&
+      meetingInfo.password.length <= 8
+    );
   };
 
   return (
@@ -65,7 +70,7 @@ function SetHostInfo({ meetingInfo, setMeetingInfo, setStep }: FunnelProps) {
           </Text>
           <PasswordInput
             value={meetingInfo.password}
-            placeholder={`숫자 4자리 이상`}
+            placeholder={`숫자 4자리 이상 8자리 이하`}
             passWordOnChange={passWordOnChange}
             page={'createMeeting'}
           />
@@ -73,16 +78,8 @@ function SetHostInfo({ meetingInfo, setMeetingInfo, setStep }: FunnelProps) {
       </HostInfoSection>
       <BottomBtnSection>
         <Button
-          typeState={
-            meetingInfo.name && meetingInfo.password.length >= 4
-              ? 'primaryActive'
-              : 'primaryDisabled'
-          }
-          onClick={
-            meetingInfo.name && meetingInfo.password.length >= 4
-              ? () => containsNonNumeric(meetingInfo.password)
-              : undefined
-          }
+          typeState={validateForm() ? 'primaryActive' : 'primaryDisabled'}
+          onClick={validateForm() ? () => containsNonNumeric(meetingInfo.password) : undefined}
         >
           <Text font={'button2'}>다음</Text>
         </Button>

--- a/src/pages/createMeeting/components/useFunnel/SetPlace.tsx
+++ b/src/pages/createMeeting/components/useFunnel/SetPlace.tsx
@@ -63,17 +63,23 @@ function SetPlace({ meetingInfo, setMeetingInfo, setStep }: FunnelProps) {
 
 export default SetPlace;
 
-const SetPlaceWrapper = styled.div``;
-
+const SetPlaceWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  width: 100%;
+`;
 const StyledBtnSection = styled.section`
   position: fixed;
   bottom: 1.2rem;
   border-radius: 50%;
+  width: 100%;
 `;
 
 const PlaceInfoSection = styled.section`
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  width: 100%;
 `;
 const PlaceSection = styled.section``;

--- a/src/pages/createMeeting/components/useFunnel/SetPlace.tsx
+++ b/src/pages/createMeeting/components/useFunnel/SetPlace.tsx
@@ -1,6 +1,7 @@
 import Button from 'components/common/atomComponents/Button';
 import PlaceInput from 'components/common/atomComponents/PlaceInput';
 import Text from 'components/common/atomComponents/Text';
+import BottomBtnSection from 'components/common/moleculesComponents/BottomBtnSection';
 import { placeType } from 'pages/createMeeting/data/meetingInfoData';
 import { FunnelProps } from 'pages/createMeeting/types/useFunnelInterface';
 import styled from 'styled-components';
@@ -39,7 +40,7 @@ function SetPlace({ meetingInfo, setMeetingInfo, setStep }: FunnelProps) {
           );
         })}
       </PlaceInfoSection>
-      <StyledBtnSection>
+      <BottomBtnSection>
         <Button
           typeState={meetingInfo.place ? 'primaryActive' : 'primaryDisabled'}
           onClick={
@@ -56,7 +57,7 @@ function SetPlace({ meetingInfo, setMeetingInfo, setStep }: FunnelProps) {
         >
           <Text font={'button2'}>다음</Text>
         </Button>
-      </StyledBtnSection>
+      </BottomBtnSection>
     </SetPlaceWrapper>
   );
 }
@@ -67,14 +68,6 @@ const SetPlaceWrapper = styled.div`
   display: flex;
   justify-content: center;
 
-  width: 100%;
-`;
-const StyledBtnSection = styled.section`
-  display: flex;
-  justify-content: center;
-  position: fixed;
-  bottom: 1.2rem;
-  border-radius: 50%;
   width: 100%;
 `;
 

--- a/src/pages/createMeeting/components/useFunnel/SetPlace.tsx
+++ b/src/pages/createMeeting/components/useFunnel/SetPlace.tsx
@@ -65,11 +65,13 @@ export default SetPlace;
 
 const SetPlaceWrapper = styled.div`
   display: flex;
-  flex-direction: column;
   justify-content: center;
+
   width: 100%;
 `;
 const StyledBtnSection = styled.section`
+  display: flex;
+  justify-content: center;
   position: fixed;
   bottom: 1.2rem;
   border-radius: 50%;

--- a/src/pages/createMeeting/components/useFunnel/SetTitle.tsx
+++ b/src/pages/createMeeting/components/useFunnel/SetTitle.tsx
@@ -56,10 +56,14 @@ const SetTitleWrapper = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
+  width: 100%;
 `;
 
 const StyledBtnSection = styled.section`
-  position: fixed;
+  position: absolute;
+  width: 100%;
+  display: flex;
+  justify-content: center;
   bottom: 1.2rem;
   border-radius: 50%;
 `;

--- a/src/pages/createMeeting/components/useFunnel/SetTitle.tsx
+++ b/src/pages/createMeeting/components/useFunnel/SetTitle.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import Button from 'components/common/atomComponents/Button';
 import Text from 'components/common/atomComponents/Text';
 import TextInput from 'components/common/atomComponents/TextInput';
+import BottomBtnSection from 'components/common/moleculesComponents/BottomBtnSection';
 import { FunnelProps, MeetingInfo } from 'pages/createMeeting/types/useFunnelInterface';
 import styled from 'styled-components';
 
@@ -26,7 +27,7 @@ function SetTitle({ meetingInfo, setMeetingInfo, setStep }: FunnelProps) {
         resetValue={resetTitle}
         placeholder={'서비스 기획 1차 회의'}
       />
-      <StyledBtnSection>
+      <BottomBtnSection>
         <Button
           typeState={
             meetingInfo.title && meetingInfo.title.length < 16 ? 'primaryActive' : 'primaryDisabled'
@@ -45,7 +46,7 @@ function SetTitle({ meetingInfo, setMeetingInfo, setStep }: FunnelProps) {
         >
           <Text font={'button2'}>다음</Text>
         </Button>
-      </StyledBtnSection>
+      </BottomBtnSection>
     </SetTitleWrapper>
   );
 }
@@ -59,11 +60,11 @@ const SetTitleWrapper = styled.div`
   width: 100%;
 `;
 
-const StyledBtnSection = styled.section`
-  position: absolute;
-  width: 100%;
-  display: flex;
-  justify-content: center;
-  bottom: 1.2rem;
-  border-radius: 50%;
-`;
+// const StyledBtnSection = styled.section`
+//   position: absolute;
+//   width: 100%;
+//   display: flex;
+//   justify-content: center;
+//   bottom: 1.2rem;
+//   border-radius: 50%;
+// `;

--- a/src/pages/cueCard/CueCard.tsx
+++ b/src/pages/cueCard/CueCard.tsx
@@ -2,6 +2,7 @@ import { useRef } from 'react';
 
 import Button from 'components/common/atomComponents/Button';
 import Text from 'components/common/atomComponents/Text';
+import BottomBtnSection from 'components/common/moleculesComponents/BottomBtnSection';
 import Header from 'components/common/moleculesComponents/Header';
 import html2canvas from 'html2canvas';
 import CueCardTitle from 'pages/cueCard/components/CueCardTitle';
@@ -32,7 +33,7 @@ function CueCard() {
       <Header position={'cueCard'} />
       <CueCardTitle main={'일정 조율 완료!'} sub={'이미 확정된 회의 일정입니다'} />
       <Qcard ref={imageRef} />
-      <ButtonSection>
+      <BottomBtnSection>
         <CopyToClipboard text={currentURL}>
           <Button typeState={'halfTertiaryActive'} onClick={notify}>
             <Text font={'button2'}>링크 복사하기</Text>
@@ -47,7 +48,7 @@ function CueCard() {
         >
           <Text font={'button2'}>이미지 저장하기</Text>
         </Button>
-      </ButtonSection>
+      </BottomBtnSection>
     </CueCardWrapper>
   );
 }
@@ -61,13 +62,4 @@ const CueCardWrapper = styled.div`
   justify-content: center;
 
   width: 100%;
-`;
-
-const ButtonSection = styled.section`
-  display: flex;
-  position: fixed;
-  bottom: 1.2rem;
-  flex-direction: row;
-  gap: 1.4rem;
-  justify-content: center;
 `;

--- a/src/pages/errorLoading/ErrorPage404.tsx
+++ b/src/pages/errorLoading/ErrorPage404.tsx
@@ -1,11 +1,13 @@
 import Error404 from 'assets/images/Error404.png';
 import Button from 'components/common/atomComponents/Button';
 import Text from 'components/common/atomComponents/Text';
-import { Link } from 'react-router-dom';
+import BottomBtnSection from 'components/common/moleculesComponents/BottomBtnSection';
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import { theme } from 'styles/theme';
 
 function ErrorPage404() {
+  const navigate = useNavigate();
   return (
     <ErrorPage404Wrapper>
       <ErrorSection>
@@ -27,13 +29,16 @@ function ErrorPage404() {
           </Text>
         </ErrorMentContainer>
       </ErrorSection>
-      <StyledBtnSection>
-        <Link to={'/'}>
-          <Button typeState={'primaryActive'}>
-            <Text font={'button2'}>홈으로 돌아가기</Text>
-          </Button>
-        </Link>
-      </StyledBtnSection>
+      <BottomBtnSection>
+        <Button
+          typeState={'primaryActive'}
+          onClick={() => {
+            navigate('/');
+          }}
+        >
+          <Text font={'button2'}>홈으로 돌아가기</Text>
+        </Button>
+      </BottomBtnSection>
     </ErrorPage404Wrapper>
   );
 }

--- a/src/pages/loginEntrance/LoginEntrance.tsx
+++ b/src/pages/loginEntrance/LoginEntrance.tsx
@@ -38,5 +38,6 @@ export default LoginEntrance;
 const LoginEntranceWrapper = styled.div`
   display: flex;
   flex-direction: column;
+  align-items: center;
   width: 100%;
 `;

--- a/src/pages/loginEntrance/components/HostComponent.tsx
+++ b/src/pages/loginEntrance/components/HostComponent.tsx
@@ -5,6 +5,7 @@ import Button from 'components/common/atomComponents/Button';
 import PasswordInput from 'components/common/atomComponents/PasswordInput';
 import Text from 'components/common/atomComponents/Text';
 import TextInput from 'components/common/atomComponents/TextInput';
+import BottomBtnSection from 'components/common/moleculesComponents/BottomBtnSection';
 import Header from 'components/common/moleculesComponents/Header';
 import TitleComponent from 'components/common/moleculesComponents/TitleComponents';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -102,7 +103,7 @@ function HostComponent({ hostInfo, setHostInfo }: HostProps) {
           />
         </HostNameSection>
       </HostInfoSection>
-      <StyledBtnSection>
+      <BottomBtnSection>
         <Button
           typeState={
             hostInfo.name && hostInfo.password.length >= 4 ? 'primaryActive' : 'primaryDisabled'
@@ -111,7 +112,7 @@ function HostComponent({ hostInfo, setHostInfo }: HostProps) {
         >
           <Text font={'button2'}>방장 페이지 접속하기</Text>
         </Button>
-      </StyledBtnSection>
+      </BottomBtnSection>
       {ismodalOpen ? <NoAvailableTimeModal setIsModalOpen={setIsModalOpen} /> : undefined}
       {isLoginModalOpen ? (
         <IncorrectInfoModal setIsLoginModalOpen={setIsLoginModalOpen} />
@@ -129,14 +130,7 @@ const HostComponentWrapper = styled.div`
   flex-direction: column;
 
   align-items: center;
-`;
-
-const StyledBtnSection = styled.section`
   width: 100%;
-  position: fixed;
-  max-width: 39rem;
-  bottom: 1.2rem;
-  border-radius: 50%;
 `;
 
 const HostNameSection = styled.section`

--- a/src/pages/loginEntrance/components/HostComponent.tsx
+++ b/src/pages/loginEntrance/components/HostComponent.tsx
@@ -97,7 +97,7 @@ function HostComponent({ hostInfo, setHostInfo }: HostProps) {
           </Text>
           <PasswordInput
             value={hostInfo.password}
-            placeholder={`숫자 4자 이상`}
+            placeholder={`숫자 4자 이상 8자리 이하`}
             passWordOnChange={passWordOnChange}
             page={'entrance'}
           />

--- a/src/pages/loginEntrance/components/HostComponent.tsx
+++ b/src/pages/loginEntrance/components/HostComponent.tsx
@@ -75,7 +75,7 @@ function HostComponent({ hostInfo, setHostInfo }: HostProps) {
     }
   };
   return (
-    <>
+    <HostComponentWrapper>
       <Header position={'login'} />
       <TitleComponent main={'방장 정보를 알려주세요'} sub={''} />
       <HostInfoSection>
@@ -118,14 +118,23 @@ function HostComponent({ hostInfo, setHostInfo }: HostProps) {
       ) : (
         undefined
       )}
-    </>
+    </HostComponentWrapper>
   );
 }
 
 export default HostComponent;
 
+const HostComponentWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  align-items: center;
+`;
+
 const StyledBtnSection = styled.section`
+  width: 100%;
   position: fixed;
+  max-width: 39rem;
   bottom: 1.2rem;
   border-radius: 50%;
 `;
@@ -134,9 +143,12 @@ const HostNameSection = styled.section`
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  width: 100%;
 `;
 const HostInfoSection = styled.div`
   display: flex;
   flex-direction: column;
   gap: 3.4rem;
+
+  width: 100%;
 `;

--- a/src/pages/loginEntrance/components/MemberComponent.tsx
+++ b/src/pages/loginEntrance/components/MemberComponent.tsx
@@ -76,6 +76,9 @@ function MemberComponent({ hostInfo, setHostInfo }: HostProps) {
 export default MemberComponent;
 
 const StyledBtnSection = styled.section`
+  display: flex;
+  justify-content: center;
+  width: 100%;
   position: fixed;
   bottom: 1.2rem;
   border-radius: 50%;
@@ -85,9 +88,12 @@ const HostNameSection = styled.section`
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  width: 100%;
 `;
 const HostInfoSection = styled.div`
   display: flex;
   flex-direction: column;
   gap: 3.4rem;
+
+  width: 100%;
 `;

--- a/src/pages/loginEntrance/components/MemberComponent.tsx
+++ b/src/pages/loginEntrance/components/MemberComponent.tsx
@@ -4,6 +4,7 @@ import { userNameAtom } from 'atoms/atom';
 import Button from 'components/common/atomComponents/Button';
 import Text from 'components/common/atomComponents/Text';
 import TextInput from 'components/common/atomComponents/TextInput';
+import BottomBtnSection from 'components/common/moleculesComponents/BottomBtnSection';
 import Header from 'components/common/moleculesComponents/Header';
 import TitleComponent from 'components/common/moleculesComponents/TitleComponents';
 import { useParams } from 'react-router';
@@ -61,28 +62,19 @@ function MemberComponent({ hostInfo, setHostInfo }: HostProps) {
           />
         </HostNameSection>
       </HostInfoSection>
-      <StyledBtnSection>
+      <BottomBtnSection>
         <Button
           typeState={hostInfo.name ? 'primaryActive' : 'secondaryDisabled'}
           onClick={hostInfo.name ? loginMember : undefined}
         >
           <Text font={'button2'}>나의 가능 시간 입력</Text>
         </Button>
-      </StyledBtnSection>
+      </BottomBtnSection>
     </>
   );
 }
 
 export default MemberComponent;
-
-const StyledBtnSection = styled.div`
-  display: flex;
-  justify-content: center;
-  width: 100%;
-  position: fixed;
-  bottom: 1.2rem;
-  padding: 0 2rem;
-`;
 
 const HostNameSection = styled.section`
   display: flex;

--- a/src/pages/loginEntrance/components/MemberComponent.tsx
+++ b/src/pages/loginEntrance/components/MemberComponent.tsx
@@ -75,13 +75,13 @@ function MemberComponent({ hostInfo, setHostInfo }: HostProps) {
 
 export default MemberComponent;
 
-const StyledBtnSection = styled.section`
+const StyledBtnSection = styled.div`
   display: flex;
   justify-content: center;
   width: 100%;
   position: fixed;
   bottom: 1.2rem;
-  border-radius: 50%;
+  padding: 0 2rem;
 `;
 
 const HostNameSection = styled.section`

--- a/src/pages/loginEntrance/components/NoAvailableTimeModal.tsx
+++ b/src/pages/loginEntrance/components/NoAvailableTimeModal.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, SetStateAction, useState } from 'react';
+import { Dispatch, SetStateAction } from 'react';
 
 import Text from 'components/common/atomComponents/Text';
 import { ExitIc } from 'components/Icon/icon';

--- a/src/pages/onBoarding/OnBoarding.tsx
+++ b/src/pages/onBoarding/OnBoarding.tsx
@@ -9,7 +9,7 @@ import PointPng from 'assets/images/point.png';
 import Button from 'components/common/atomComponents/Button';
 import Text from 'components/common/atomComponents/Text';
 import Header from 'components/common/moleculesComponents/Header';
-import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import { Autoplay, Navigation, Pagination } from 'swiper/modules';
 import { Swiper, SwiperSlide } from 'swiper/react';
@@ -44,11 +44,15 @@ const slides = [
 ];
 
 function OnBoarding() {
+  const navigate = useNavigate();
+  const handleCreateMeeting = () => {
+    navigate('/meet/create?step=title');
+  };
   return (
     <>
       <OnboardingWrapper>
         <Header position={'onBoarding'} />
-        <SwiperSection>
+        <>
           <SwiperContext>
             <Swiper
               spaceBetween={30}
@@ -76,13 +80,11 @@ function OnBoarding() {
               ))}
             </Swiper>
           </SwiperContext>
-        </SwiperSection>
+        </>
         <ButtonSection>
-          <Link to={'/meet/create?step=title'}>
-            <Button typeState={'primaryActive'}>
-              <Text font={'button2'}>약속 생성하기</Text>
-            </Button>
-          </Link>
+          <Button typeState={'primaryActive'} onClick={handleCreateMeeting}>
+            <Text font={'button2'}>약속 생성하기</Text>
+          </Button>
         </ButtonSection>
       </OnboardingWrapper>
     </>
@@ -92,6 +94,10 @@ function OnBoarding() {
 export default OnBoarding;
 
 const OnboardingWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  align-items: center;
   width: 100%;
 `;
 
@@ -99,8 +105,6 @@ const SwiperContext = styled.div`
   width: 100%;
   height: 50rem;
 `;
-
-const SwiperSection = styled.section``;
 
 const StyledSwiperSlide = styled(SwiperSlide)`
   display: flex;
@@ -118,5 +122,8 @@ const ExplainContainer = styled.section``;
 
 const ButtonSection = styled.section`
   position: fixed;
+  width: 100%;
+  display: flex;
+  justify-content: center;
   bottom: 1.2rem;
 `;

--- a/src/pages/onBoarding/OnBoarding.tsx
+++ b/src/pages/onBoarding/OnBoarding.tsx
@@ -8,6 +8,7 @@ import MakePng from 'assets/images/make.png';
 import PointPng from 'assets/images/point.png';
 import Button from 'components/common/atomComponents/Button';
 import Text from 'components/common/atomComponents/Text';
+import BottomBtnSection from 'components/common/moleculesComponents/BottomBtnSection';
 import Header from 'components/common/moleculesComponents/Header';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
@@ -73,19 +74,19 @@ function OnBoarding() {
                   {/* <SvgContainer>{slide.icon}</SvgContainer> */}
                   {/* 로딩 속도로 차선책 png code */}
                   <SvgContainer>{slide.icon}</SvgContainer>
-                  <ExplainContainer>
+                  <>
                     <Explain main={slide.main} sub1={slide.sub1} sub2={slide.sub2} />
-                  </ExplainContainer>
+                  </>
                 </StyledSwiperSlide>
               ))}
             </Swiper>
           </SwiperContext>
         </>
-        <ButtonSection>
+        <BottomBtnSection>
           <Button typeState={'primaryActive'} onClick={handleCreateMeeting}>
             <Text font={'button2'}>약속 생성하기</Text>
           </Button>
-        </ButtonSection>
+        </BottomBtnSection>
       </OnboardingWrapper>
     </>
   );
@@ -116,14 +117,4 @@ const SvgContainer = styled.section`
     width: 33rem;
     height: 33rem;
   }
-`;
-
-const ExplainContainer = styled.section``;
-
-const ButtonSection = styled.section`
-  position: fixed;
-  width: 100%;
-  display: flex;
-  justify-content: center;
-  bottom: 1.2rem;
 `;

--- a/src/pages/selectSchedule/components/Description.tsx
+++ b/src/pages/selectSchedule/components/Description.tsx
@@ -67,6 +67,7 @@ const DescriptionWrapper = styled.div`
   display: flex;
   position: relative;
   margin: 2rem 0;
+  width: 100%;
 `;
 
 const Texts = styled.div`
@@ -75,7 +76,7 @@ const Texts = styled.div`
   border-radius: 0.8rem;
   background-color: ${theme.colors.grey9};
   padding: 1.5rem 2.4rem;
-  width: 33.5rem;
+  width: 100%;
 `;
 const OneLine = styled.div`
   display: flex;

--- a/src/pages/selectSchedule/components/selectPriority/PriorityCta.tsx
+++ b/src/pages/selectSchedule/components/selectPriority/PriorityCta.tsx
@@ -42,7 +42,7 @@ const BtnDim = styled.div`
   gap: 1rem;
   align-items: end;
   justify-content: center;
-  z-index: 2;
+  z-index: 1;
 
   margin-top: 3rem;
   background: ${({ theme }) => theme.colors.dim_gradient};

--- a/src/pages/selectSchedule/components/selectPriority/PriorityDropdown.tsx
+++ b/src/pages/selectSchedule/components/selectPriority/PriorityDropdown.tsx
@@ -192,10 +192,10 @@ const PriorityDropdownWrapper = styled.div`
   flex-direction: column;
   gap: 1.2rem;
   justify-content: start;
-
+  align-items: center;
   margin-top: 3rem;
   margin-bottom: 7.5rem;
-  width: 100%;
+  width: 33.5rem;
   height: 18rem;
 `;
 

--- a/src/pages/selectSchedule/components/selectTimeSlot/TimeSlotCta.tsx
+++ b/src/pages/selectSchedule/components/selectTimeSlot/TimeSlotCta.tsx
@@ -51,8 +51,7 @@ const BtnDim = styled.div`
 
   margin-top: 3rem;
   background: ${({ theme }) => theme.colors.dim_gradient};
-  padding-bottom: 2.9rem;
-
+  padding: 0 2rem 2.9rem 2rem;
   width: 100%;
   height: 16.4rem;
 

--- a/src/pages/steppingStone/components/SteppingBody.tsx
+++ b/src/pages/steppingStone/components/SteppingBody.tsx
@@ -77,12 +77,6 @@ function SteppingBody({ steppingType, meetingTitle }: SteppingProps) {
 
 export default SteppingBody;
 
-// const LinkToolTipIcon = styled(LinkTooltipIc)`
-//   position: relative;
-//   left: 10.3rem;
-//   cursor: pointer;
-// `;
-
 const ImageSection = styled.section`
   display: flex;
   align-items: center;

--- a/src/pages/steppingStone/components/SteppingBtnSection.tsx
+++ b/src/pages/steppingStone/components/SteppingBtnSection.tsx
@@ -2,12 +2,12 @@
 
 import Button from 'components/common/atomComponents/Button';
 import Text from 'components/common/atomComponents/Text';
+import BottomBtnSection from 'components/common/moleculesComponents/BottomBtnSection';
 import CopyToClipboard from 'react-copy-to-clipboard';
 import { useParams } from 'react-router';
-import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import { notify } from 'utils/toast/copyLinkToast';
-
 
 interface SteppingProps {
   steppingType: string;
@@ -16,19 +16,18 @@ interface SteppingProps {
 function SteppingBtnSection({ steppingType }: SteppingProps) {
   const { meetingId } = useParams();
 
+  const navigate=useNavigate();
 
   return (
     <>
-      <StyledBtnSection>
+      <BottomBtnSection>
         {
           {
             hostScheduleComplete: (
               <>
-                <Link to={`/host/${meetingId}`}>
-                  <Button typeState={'halfTertiaryActive'}>
+                  <Button typeState={'halfTertiaryActive'} onClick={()=>navigate(`/host/${meetingId}`)}>
                     <Text font={'button2'}>방장페이지 입장</Text>
                   </Button>
-                </Link>
                 <CopyToClipboard
                   text={`${import.meta.env.VITE_WEB_IP}/meet/${meetingId}`}
                 >
@@ -40,30 +39,24 @@ function SteppingBtnSection({ steppingType }: SteppingProps) {
             ),
             meetEntrance: (
               <>
-                <Link to={`/login/host/${meetingId}`}>
-                  <Button typeState={'halfSecondaryActive'}>
+                  <Button typeState={'halfSecondaryActive'} onClick={()=>navigate(`/login/host/${meetingId}`)}>
                     <Text font={'button2'}>방장 입장하기</Text>
                   </Button>
-                </Link>
-                <Link to={`/login/member/${meetingId}`}>
-                  <Button typeState={'halfPrimaryActive'}>
+                  <Button typeState={'halfPrimaryActive'} onClick={()=>navigate(`/login/member/${meetingId}`)}>
                     <Text font={'button2'}>팀원 입장하기</Text>
                   </Button>
-                </Link>
               </>
             ),
             memberScheduleComplete: (
               <>
-                <Link to={`/`}>
-                  <Button typeState={'primaryActive'}>
+                  <Button typeState={'primaryActive'} onClick={()=>navigate("/")}>
                     <Text font={'button2'}>홈으로 돌아가기</Text>
                   </Button>
-                </Link>
               </>
             ),
           }[steppingType]
         }
-      </StyledBtnSection>
+      </BottomBtnSection>
     </>
   );
 }

--- a/src/styles/globalStyles.ts
+++ b/src/styles/globalStyles.ts
@@ -12,7 +12,9 @@ const GlobalStyle = createGlobalStyle`
 
 }
 
-
+input {
+  margin:0;
+}
   html, body {
 
   margin: 0 auto;


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat/#{이슈번호}] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 🌀 해당 이슈 번호

- close #323 

## 🔹 어떤 것을 변경했나요?

- [x] 기존 375px로 고정되어있던 페이지에서 모든페이지 너비를 430px로 두고 그 이하의 뷰포트에서는 100%로 적용되게 반응형을 고려한 뷰로 변경하였습니다.
- [x] 이에 대한 변경으로 버튼 크기도 유동적으로 적용되도록 변경하였습니다.
- [x] btnWrapper styled-components가 중복되어 사용되는것을 확인하고 moleculesComponent로 재사용가능하게 만들었습니다.  `BottomBtnWrapper` 컴포넌트 안에 children으로 버튼 컴포넌트를 넣으면 전체 너비에 맞게 버튼을 가운데로 정렬해주고, 버튼이 두개이상일 땐 gap을 적용합니다. 
- [x] 달력 뷰를 확인해보니 피그마와 상이한 부분이 많아 년-월 텍스트 변경, 요일텍스트와 달력날짜와의 간격이 안맞는 부분을 수정하였습니다.
- [x] 바텀시트 역시 모바일뷰에 따라 다른 크기로 responsive하게 변경하였습니다.
- [x] QA에서 발견한 로딩스피너 중앙정렬을 적용하였습니다.

## 🔹 어떻게 구현했나요?
 `window.innerWidth || document.documentElement.clientWidth` 로 뷰포트의 크기를 확인하여 뷰포트와 430px중 더 작은 너비로 전체 appWrapper의 크기를 지정해주면서 responsive한 모바일 뷰를 구현하였습니다. 
데스크탑 환경에서는 430px이 더 작은 값이니 430px로 보입니다.

## 🔹 PR 포인트를 알려주세요!
BottomBtnWrapper 가 중복되고 atom 컴포넌트인 Button 컴포넌트를 활용할 수 있는 명확한 moleculesComponent라고 생각하는데 이부분에 대해 은서님의 생각도 궁금합니다

## 🔹 스크린샷을 남겨주세요!


https://github.com/user-attachments/assets/35e6e044-429f-4583-825e-55d51356bd98


